### PR TITLE
🚚 Rename `frozen_or_unfrozen_dict` to `params` in `serialize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ model = SingleLayerModel(features=1)
 rng = jax.random.PRNGKey(0)
 params = model.init(rng, jnp.ones((1, 1)))
 
-serialized = serialize(frozen_or_unfrozen_dict=params)
+serialized = serialize(params=params)
 assert isinstance(serialized, bytes)
 assert len(serialized) > 0
 ```

--- a/examples/serialization_with_safejax.py
+++ b/examples/serialization_with_safejax.py
@@ -20,7 +20,7 @@ model = SingleLayerModel(features=1)
 rng = jax.random.PRNGKey(0)
 params = model.init(rng, jnp.ones((1, 1)))
 
-serialized = serialize(frozen_or_unfrozen_dict=params)
+serialized = serialize(params=params)
 assert isinstance(serialized, bytes)
 assert len(serialized) > 0
 

--- a/src/safejax/flax.py
+++ b/src/safejax/flax.py
@@ -13,7 +13,7 @@ __all__ = ["serialize", "deserialize"]
 
 
 def flatten_dict(
-    frozen_or_unfrozen_dict: Union[Dict[str, Any], FrozenDict],
+    params: Union[Dict[str, Any], FrozenDict],
     key_prefix: Union[str, None] = None,
 ) -> Union[Dict[str, jnp.DeviceArray], Dict[str, np.ndarray]]:
     """
@@ -27,25 +27,25 @@ def flatten_dict(
     Reference at https://gist.github.com/Narsil/d5b0d747e5c8c299eb6d82709e480e3d
 
     Args:
-        frozen_or_unfrozen_dict: A `FrozenDict` or a `Dict` containing the model parameters.
+        params: A `FrozenDict` or a `Dict` containing the model parameters.
         key_prefix: A prefix to prepend to the keys of the flattened dictionary.
 
     Returns:
         A flattened dictionary containing the model parameters.
     """
     weights = {}
-    for key, value in frozen_or_unfrozen_dict.items():
+    for key, value in params.items():
         key = f"{key_prefix}.{key}" if key_prefix else key
         if isinstance(value, jnp.DeviceArray) or isinstance(value, np.ndarray):
             weights[key] = value
             continue
         if isinstance(value, FrozenDict) or isinstance(value, Dict):
-            weights.update(flatten_dict(frozen_or_unfrozen_dict=value, key_prefix=key))
+            weights.update(flatten_dict(params=value, key_prefix=key))
     return weights
 
 
 def serialize(
-    frozen_or_unfrozen_dict: Union[Dict[str, Any], FrozenDict],
+    params: Union[Dict[str, Any], FrozenDict],
     filename: Union[PathLike, None] = None,
 ) -> Union[bytes, PathLike]:
     """
@@ -55,13 +55,13 @@ def serialize(
     otherwise the model is saved to the provided `filename` and the `filename` is returned.
 
     Args:
-        frozen_or_unfrozen_dict: A `FrozenDict` or a `Dict` containing the model parameters.
+        params: A `FrozenDict` or a `Dict` containing the model parameters.
         filename: The path to the file where the model will be saved.
 
     Returns:
         The serialized model as a `bytes` object or the path to the file where the model was saved.
     """
-    flattened_dict = flatten_dict(frozen_or_unfrozen_dict=frozen_or_unfrozen_dict)
+    flattened_dict = flatten_dict(params=params)
     if not filename:
         return save(tensors=flattened_dict)
     else:

--- a/tests/test_flax.py
+++ b/tests/test_flax.py
@@ -8,7 +8,7 @@ from safejax.flax import deserialize, serialize
 
 @pytest.mark.usefixtures("single_layer_model_params")
 def test_serialize(single_layer_model_params: FrozenDict) -> None:
-    serialized = serialize(frozen_or_unfrozen_dict=single_layer_model_params)
+    serialized = serialize(params=single_layer_model_params)
     assert isinstance(serialized, bytes)
     assert len(serialized) > 0
 
@@ -18,7 +18,7 @@ def test_serialize_to_file(
     single_layer_model_params: FrozenDict, safetensors_file: Path
 ) -> None:
     safetensors_file = serialize(
-        frozen_or_unfrozen_dict=single_layer_model_params, filename=safetensors_file
+        params=single_layer_model_params, filename=safetensors_file
     )
     assert isinstance(safetensors_file, Path)
     assert safetensors_file.exists()
@@ -26,7 +26,7 @@ def test_serialize_to_file(
 
 @pytest.mark.usefixtures("single_layer_model_params")
 def test_deserialize(single_layer_model_params: FrozenDict) -> None:
-    serialized = serialize(frozen_or_unfrozen_dict=single_layer_model_params)
+    serialized = serialize(params=single_layer_model_params)
     deserialized = deserialize(path_or_buf=serialized)
     assert isinstance(deserialized, FrozenDict)
     assert len(deserialized) > 0
@@ -37,7 +37,7 @@ def test_deserialize_from_file(
     single_layer_model_params: FrozenDict, safetensors_file: Path
 ) -> None:
     safetensors_file = serialize(
-        frozen_or_unfrozen_dict=single_layer_model_params, filename=safetensors_file
+        params=single_layer_model_params, filename=safetensors_file
     )
     deserialized = deserialize(path_or_buf=safetensors_file)
     assert isinstance(deserialized, FrozenDict)


### PR DESCRIPTION
## ✨ Features

- Rename `frozen_or_unfrozen_dict` to `params` in `serialize`

## 🧪 Tests

- [X] Did you implement unit tests if required?

If the above checkbox is checked, describe how you unit-tested it.

Update `test_flax` accordingly, as it was using named-parameters, so `frozen_or_unfrozen_dict` had to be renamed to `params`.