### PR TITLE
🧪 Add more unit test cases e.g. ResNet FrozenDict

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -36,8 +36,8 @@ jobs:
 
       - name: check-quality
         run: |
-          ruff src tests
-          black --check --diff --preview src tests
+          ruff src tests benchmarks examples
+          black --check --diff --preview src tests benchmarks examples
 
   run-tests:
     needs: check-quality

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ model = SingleLayerModel(features=1)
 rng = jax.random.PRNGKey(0)
 params = model.init(rng, jnp.ones((1, 1)))
 
-serialized = serialize(frozen_or_unfrozen_dict=params)
+serialized = serialize(params=params)
 assert isinstance(serialized, bytes)
 assert len(serialized) > 0
 ```

--- a/benchmarks/hyperfine/resnet50.py
+++ b/benchmarks/hyperfine/resnet50.py
@@ -1,0 +1,27 @@
+import sys
+
+import jax
+from flax.serialization import to_bytes
+from flaxmodels.resnet import ResNet50
+from jax import numpy as jnp
+
+from safejax.flax import serialize
+
+resnet50 = ResNet50()
+params = resnet50.init(jax.random.PRNGKey(42), jnp.ones((1, 224, 224, 3)))
+
+
+def serialization_safejax():
+    _ = serialize(params)
+
+
+def serialization_flax():
+    _ = to_bytes(params)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        raise ValueError("Please provide a function name to run as an argument")
+    if sys.argv[1] not in globals():
+        raise ValueError(f"Function {sys.argv[1]} not found")
+    globals()[sys.argv[1]]()

--- a/benchmarks/hyperfine/single_layer.py
+++ b/benchmarks/hyperfine/single_layer.py
@@ -1,0 +1,39 @@
+import sys
+
+import jax
+import jax.numpy as jnp
+from flax import linen as nn
+from flax.serialization import to_bytes
+
+from safejax.flax import serialize
+
+
+class SingleLayerModel(nn.Module):
+    features: int
+
+    @nn.compact
+    def __call__(self, x):
+        x = nn.Dense(features=self.features)(x)
+        return x
+
+
+model = SingleLayerModel(features=1)
+
+rng = jax.random.PRNGKey(0)
+params = model.init(rng, jnp.ones((1, 1)))
+
+
+def serialization_safejax():
+    _ = serialize(params)
+
+
+def serialization_flax():
+    _ = to_bytes(params)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        raise ValueError("Please provide a function name to run as an argument")
+    if sys.argv[1] not in globals():
+        raise ValueError(f"Function {sys.argv[1]} not found")
+    globals()[sys.argv[1]]()

--- a/benchmarks/resnet50.py
+++ b/benchmarks/resnet50.py
@@ -1,0 +1,24 @@
+from time import perf_counter
+
+import jax
+from flax.serialization import to_bytes
+from flaxmodels.resnet import ResNet50
+from jax import numpy as jnp
+
+from safejax.flax import serialize
+
+resnet50 = ResNet50()
+params = resnet50.init(jax.random.PRNGKey(42), jnp.ones((1, 224, 224, 3)))
+
+
+start_time = perf_counter()
+for _ in range(100):
+    serialize(params)
+end_time = perf_counter()
+print(f"safejax (100 runs): {end_time - start_time:0.4f} s")
+
+start_time = perf_counter()
+for _ in range(100):
+    to_bytes(params)
+end_time = perf_counter()
+print(f"flax (100 runs): {end_time - start_time:0.4f} s")

--- a/benchmarks/single_layer.py
+++ b/benchmarks/single_layer.py
@@ -1,9 +1,9 @@
-import sys
+from time import perf_counter
 
 import jax
-import jax.numpy as jnp
 from flax import linen as nn
 from flax.serialization import to_bytes
+from jax import numpy as jnp
 
 from safejax.flax import serialize
 
@@ -23,13 +23,14 @@ rng = jax.random.PRNGKey(0)
 params = model.init(rng, jnp.ones((1, 1)))
 
 
-def benchmark_safejax():
-    _ = serialize(params)
+start_time = perf_counter()
+for _ in range(100):
+    serialize(params)
+end_time = perf_counter()
+print(f"safejax (100 runs): {end_time - start_time:0.4f} s")
 
-
-def benchmark_flax():
-    _ = to_bytes(params)
-
-
-if __name__ == "__main__":
-    globals()[sys.argv[1]]()
+start_time = perf_counter()
+for _ in range(100):
+    to_bytes(params)
+end_time = perf_counter()
+print(f"flax (100 runs): {end_time - start_time:0.4f} s")

--- a/examples/serialization_with_flax.py
+++ b/examples/serialization_with_flax.py
@@ -1,6 +1,5 @@
 import jax
 from flax import linen as nn
-from flax.core.frozen_dict import FrozenDict
 from flax.serialization import from_bytes, to_bytes
 from jax import numpy as jnp
 

--- a/examples/serialization_with_safejax.py
+++ b/examples/serialization_with_safejax.py
@@ -20,7 +20,7 @@ model = SingleLayerModel(features=1)
 rng = jax.random.PRNGKey(0)
 params = model.init(rng, jnp.ones((1, 1)))
 
-serialized = serialize(frozen_or_unfrozen_dict=params)
+serialized = serialize(params=params)
 assert isinstance(serialized, bytes)
 assert len(serialized) > 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,12 +58,12 @@ features = [
 
 [tool.hatch.envs.quality.scripts]
 check = [
-  "ruff src tests",
-  "black --check --diff --preview src tests",
+  "ruff src tests benchmarks examples",
+  "black --check --diff --preview src tests benchmarks examples",
 ]
 format = [
-  "ruff --fix src tests",
-  "black --preview src tests",
+  "ruff --fix src tests benchmarks examples",
+  "black --preview src tests benchmarks examples",
   "check",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ quality = [
 ]
 tests = [
   "pytest~=7.1.2",
+  "pytest-lazy-fixture~=0.6.3",
 ]
 
 [tool.hatch.envs.quality]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ Source = "https://github.com/alvarobartt/safejax"
 [tool.hatch.version]
 path = "src/safejax/__init__.py"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [project.optional-dependencies]
 quality = [
   "black~=22.10.0",
@@ -45,6 +48,7 @@ quality = [
 tests = [
   "pytest~=7.1.2",
   "pytest-lazy-fixture~=0.6.3",
+  "flaxmodels @ git+https://github.com/matthias-wright/flaxmodels.git",
 ]
 
 [tool.hatch.envs.quality]

--- a/src/safejax/__init__.py
+++ b/src/safejax/__init__.py
@@ -1,4 +1,4 @@
 """`safejax `: Serialize JAX/Flax models with `safetensors`"""
 
 __author__ = "Alvaro Bartolome <alvarobartt@yahoo.com>"
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/src/safejax/flax.py
+++ b/src/safejax/flax.py
@@ -13,7 +13,7 @@ __all__ = ["serialize", "deserialize"]
 
 
 def flatten_dict(
-    frozen_or_unfrozen_dict: Union[Dict[str, Any], FrozenDict],
+    params: Union[Dict[str, Any], FrozenDict],
     key_prefix: Union[str, None] = None,
 ) -> Union[Dict[str, jnp.DeviceArray], Dict[str, np.ndarray]]:
     """
@@ -27,25 +27,25 @@ def flatten_dict(
     Reference at https://gist.github.com/Narsil/d5b0d747e5c8c299eb6d82709e480e3d
 
     Args:
-        frozen_or_unfrozen_dict: A `FrozenDict` or a `Dict` containing the model parameters.
+        params: A `FrozenDict` or a `Dict` containing the model parameters.
         key_prefix: A prefix to prepend to the keys of the flattened dictionary.
 
     Returns:
         A flattened dictionary containing the model parameters.
     """
     weights = {}
-    for key, value in frozen_or_unfrozen_dict.items():
+    for key, value in params.items():
         key = f"{key_prefix}.{key}" if key_prefix else key
         if isinstance(value, jnp.DeviceArray) or isinstance(value, np.ndarray):
             weights[key] = value
             continue
         if isinstance(value, FrozenDict) or isinstance(value, Dict):
-            weights.update(flatten_dict(frozen_or_unfrozen_dict=value, key_prefix=key))
+            weights.update(flatten_dict(params=value, key_prefix=key))
     return weights
 
 
 def serialize(
-    frozen_or_unfrozen_dict: Union[Dict[str, Any], FrozenDict],
+    params: Union[Dict[str, Any], FrozenDict],
     filename: Union[PathLike, None] = None,
 ) -> Union[bytes, PathLike]:
     """
@@ -55,13 +55,13 @@ def serialize(
     otherwise the model is saved to the provided `filename` and the `filename` is returned.
 
     Args:
-        frozen_or_unfrozen_dict: A `FrozenDict` or a `Dict` containing the model parameters.
+        params: A `FrozenDict` or a `Dict` containing the model parameters.
         filename: The path to the file where the model will be saved.
 
     Returns:
         The serialized model as a `bytes` object or the path to the file where the model was saved.
     """
-    flattened_dict = flatten_dict(frozen_or_unfrozen_dict=frozen_or_unfrozen_dict)
+    flattened_dict = flatten_dict(params=params)
     if not filename:
         return save(tensors=flattened_dict)
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,10 @@ import jax.numpy as jnp
 import pytest
 from flax import linen as nn
 from flax.core.frozen_dict import FrozenDict
+from flaxmodels.resnet import ResNet50
 
 
-class SingleLayerModel(nn.Module):
+class SingleLayer(nn.Module):
     features: int
 
     @nn.compact
@@ -17,15 +18,27 @@ class SingleLayerModel(nn.Module):
 
 
 @pytest.fixture
-def single_layer_model() -> nn.Module:
-    return SingleLayerModel(features=1)
+def single_layer() -> nn.Module:
+    return SingleLayer(features=1)
 
 
 @pytest.fixture
-def single_layer_model_params(single_layer_model: nn.Module) -> FrozenDict:
+def single_layer_params(single_layer: nn.Module) -> FrozenDict:
     # https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#fixtures-can-request-other-fixtures
     rng = jax.random.PRNGKey(0)
-    params = single_layer_model.init(rng, jnp.ones((1, 1)))
+    params = single_layer.init(rng, jnp.ones((1, 1)))
+    return params
+
+
+@pytest.fixture
+def resnet50() -> nn.Module:
+    return ResNet50()
+
+
+@pytest.fixture
+def resnet50_params(resnet50: nn.Module) -> FrozenDict:
+    rng = jax.random.PRNGKey(0)
+    params = resnet50.init(rng, jnp.ones((1, 224, 224, 3)))
     return params
 
 

--- a/tests/test_flax.py
+++ b/tests/test_flax.py
@@ -6,39 +6,57 @@ from flax.core.frozen_dict import FrozenDict
 from safejax.flax import deserialize, serialize
 
 
-@pytest.mark.usefixtures("single_layer_model_params")
-def test_serialize(single_layer_model_params: FrozenDict) -> None:
-    serialized = serialize(params=single_layer_model_params)
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("single_layer_params"),
+        pytest.lazy_fixture("resnet50_params"),
+    ],
+)
+def test_serialize(params: FrozenDict) -> None:
+    serialized = serialize(params=params)
     assert isinstance(serialized, bytes)
     assert len(serialized) > 0
 
 
-@pytest.mark.usefixtures("single_layer_model_params", "safetensors_file")
-def test_serialize_to_file(
-    single_layer_model_params: FrozenDict, safetensors_file: Path
-) -> None:
-    safetensors_file = serialize(
-        params=single_layer_model_params, filename=safetensors_file
-    )
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("single_layer_params"),
+        pytest.lazy_fixture("resnet50_params"),
+    ],
+)
+@pytest.mark.usefixtures("safetensors_file")
+def test_serialize_to_file(params: FrozenDict, safetensors_file: Path) -> None:
+    safetensors_file = serialize(params=params, filename=safetensors_file)
     assert isinstance(safetensors_file, Path)
     assert safetensors_file.exists()
 
 
-@pytest.mark.usefixtures("single_layer_model_params")
-def test_deserialize(single_layer_model_params: FrozenDict) -> None:
-    serialized = serialize(params=single_layer_model_params)
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("single_layer_params"),
+        pytest.lazy_fixture("resnet50_params"),
+    ],
+)
+def test_deserialize(params: FrozenDict) -> None:
+    serialized = serialize(params=params)
     deserialized = deserialize(path_or_buf=serialized)
     assert isinstance(deserialized, FrozenDict)
     assert len(deserialized) > 0
 
 
-@pytest.mark.usefixtures("single_layer_model_params", "safetensors_file")
-def test_deserialize_from_file(
-    single_layer_model_params: FrozenDict, safetensors_file: Path
-) -> None:
-    safetensors_file = serialize(
-        params=single_layer_model_params, filename=safetensors_file
-    )
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("single_layer_params"),
+        pytest.lazy_fixture("resnet50_params"),
+    ],
+)
+@pytest.mark.usefixtures("safetensors_file")
+def test_deserialize_from_file(params: FrozenDict, safetensors_file: Path) -> None:
+    safetensors_file = serialize(params=params, filename=safetensors_file)
     deserialized = deserialize(path_or_buf=safetensors_file)
     assert isinstance(deserialized, FrozenDict)
     assert len(deserialized) > 0

--- a/tests/test_flax.py
+++ b/tests/test_flax.py
@@ -6,7 +6,7 @@ from flax.core.frozen_dict import FrozenDict
 from safejax.flax import deserialize, serialize
 
 
-@pytest.mark.usefixtures("single_layer_model", "single_layer_model_params")
+@pytest.mark.usefixtures("single_layer_model_params")
 def test_serialize(single_layer_model_params: FrozenDict) -> None:
     serialized = serialize(frozen_or_unfrozen_dict=single_layer_model_params)
     assert isinstance(serialized, bytes)
@@ -24,7 +24,7 @@ def test_serialize_to_file(
     assert safetensors_file.exists()
 
 
-@pytest.mark.usefixtures("single_layer_model", "single_layer_model_params")
+@pytest.mark.usefixtures("single_layer_model_params")
 def test_deserialize(single_layer_model_params: FrozenDict) -> None:
     serialized = serialize(frozen_or_unfrozen_dict=single_layer_model_params)
     deserialized = deserialize(path_or_buf=serialized)

--- a/tests/test_flax.py
+++ b/tests/test_flax.py
@@ -8,7 +8,7 @@ from safejax.flax import deserialize, serialize
 
 @pytest.mark.usefixtures("single_layer_model_params")
 def test_serialize(single_layer_model_params: FrozenDict) -> None:
-    serialized = serialize(frozen_or_unfrozen_dict=single_layer_model_params)
+    serialized = serialize(params=single_layer_model_params)
     assert isinstance(serialized, bytes)
     assert len(serialized) > 0
 
@@ -18,7 +18,7 @@ def test_serialize_to_file(
     single_layer_model_params: FrozenDict, safetensors_file: Path
 ) -> None:
     safetensors_file = serialize(
-        frozen_or_unfrozen_dict=single_layer_model_params, filename=safetensors_file
+        params=single_layer_model_params, filename=safetensors_file
     )
     assert isinstance(safetensors_file, Path)
     assert safetensors_file.exists()
@@ -26,7 +26,7 @@ def test_serialize_to_file(
 
 @pytest.mark.usefixtures("single_layer_model_params")
 def test_deserialize(single_layer_model_params: FrozenDict) -> None:
-    serialized = serialize(frozen_or_unfrozen_dict=single_layer_model_params)
+    serialized = serialize(params=single_layer_model_params)
     deserialized = deserialize(path_or_buf=serialized)
     assert isinstance(deserialized, FrozenDict)
     assert len(deserialized) > 0
@@ -37,7 +37,7 @@ def test_deserialize_from_file(
     single_layer_model_params: FrozenDict, safetensors_file: Path
 ) -> None:
     safetensors_file = serialize(
-        frozen_or_unfrozen_dict=single_layer_model_params, filename=safetensors_file
+        params=single_layer_model_params, filename=safetensors_file
     )
     deserialized = deserialize(path_or_buf=safetensors_file)
     assert isinstance(deserialized, FrozenDict)


### PR DESCRIPTION
## ✨ Features

- Add `flaxmodels.resnet.ResNet50` in both `tests/` and `benchmarks/`
- Run `ruff` and `black` over both `examples/` and `benchmarks/` too

## 🧪 Tests

- [X] Did you implement unit tests if required?

If the above checkbox is checked, describe how you unit-tested it.

Keep the same unit tests but add ResNet50 as a `pytest.fixture` in order to test `safejax` on more complex `FrozenDict` structures.