### PR TITLE
✨ Add `benchmarks/resnet50.py`

### DIFF
--- a/benchmarks/hyperfine/resnet50.py
+++ b/benchmarks/hyperfine/resnet50.py
@@ -1,0 +1,27 @@
+import sys
+
+import jax
+from flax.serialization import to_bytes
+from flaxmodels.resnet import ResNet50
+from jax import numpy as jnp
+
+from safejax.flax import serialize
+
+resnet50 = ResNet50()
+params = resnet50.init(jax.random.PRNGKey(42), jnp.ones((1, 224, 224, 3)))
+
+
+def serialization_safejax():
+    _ = serialize(params)
+
+
+def serialization_flax():
+    _ = to_bytes(params)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        raise ValueError("Please provide a function name to run as an argument")
+    if sys.argv[1] not in globals():
+        raise ValueError(f"Function {sys.argv[1]} not found")
+    globals()[sys.argv[1]]()

--- a/benchmarks/hyperfine/single_layer.py
+++ b/benchmarks/hyperfine/single_layer.py
@@ -1,0 +1,39 @@
+import sys
+
+import jax
+import jax.numpy as jnp
+from flax import linen as nn
+from flax.serialization import to_bytes
+
+from safejax.flax import serialize
+
+
+class SingleLayerModel(nn.Module):
+    features: int
+
+    @nn.compact
+    def __call__(self, x):
+        x = nn.Dense(features=self.features)(x)
+        return x
+
+
+model = SingleLayerModel(features=1)
+
+rng = jax.random.PRNGKey(0)
+params = model.init(rng, jnp.ones((1, 1)))
+
+
+def serialization_safejax():
+    _ = serialize(params)
+
+
+def serialization_flax():
+    _ = to_bytes(params)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        raise ValueError("Please provide a function name to run as an argument")
+    if sys.argv[1] not in globals():
+        raise ValueError(f"Function {sys.argv[1]} not found")
+    globals()[sys.argv[1]]()

--- a/benchmarks/resnet50.py
+++ b/benchmarks/resnet50.py
@@ -1,0 +1,24 @@
+from time import perf_counter
+
+import jax
+from flax.serialization import to_bytes
+from flaxmodels.resnet import ResNet50
+from jax import numpy as jnp
+
+from safejax.flax import serialize
+
+resnet50 = ResNet50()
+params = resnet50.init(jax.random.PRNGKey(42), jnp.ones((1, 224, 224, 3)))
+
+
+start_time = perf_counter()
+for _ in range(100):
+    serialize(params)
+end_time = perf_counter()
+print(f"safejax (100 runs): {end_time - start_time:0.4f} s")
+
+start_time = perf_counter()
+for _ in range(100):
+    to_bytes(params)
+end_time = perf_counter()
+print(f"flax (100 runs): {end_time - start_time:0.4f} s")

--- a/benchmarks/single_layer.py
+++ b/benchmarks/single_layer.py
@@ -1,9 +1,9 @@
-import sys
+from time import perf_counter
 
 import jax
-import jax.numpy as jnp
 from flax import linen as nn
 from flax.serialization import to_bytes
+from jax import numpy as jnp
 
 from safejax.flax import serialize
 
@@ -23,13 +23,14 @@ rng = jax.random.PRNGKey(0)
 params = model.init(rng, jnp.ones((1, 1)))
 
 
-def benchmark_safejax():
-    _ = serialize(params)
+start_time = perf_counter()
+for _ in range(100):
+    serialize(params)
+end_time = perf_counter()
+print(f"safejax (100 runs): {end_time - start_time:0.4f} s")
 
-
-def benchmark_flax():
-    _ = to_bytes(params)
-
-
-if __name__ == "__main__":
-    globals()[sys.argv[1]]()
+start_time = perf_counter()
+for _ in range(100):
+    to_bytes(params)
+end_time = perf_counter()
+print(f"flax (100 runs): {end_time - start_time:0.4f} s")


### PR DESCRIPTION
## ✨ Features

- Move `benchmark.py` to `benchmarks/single_layer.py`
- Add `benchmarks/resnet50.py`
    - Those proof that `safejax.flax.serialize` is way faster than `flax.serialization.to_bytes`
- Add `benchmarks/hyperfine/` for Python scripts intended to be run with `hyperfine`
- Update `README.md` with some benchmark conclusions