### PR TITLE
✨ `safejax` support for `objax` model params

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.192
+    rev: 'v0.0.194'
     hooks:
       - id: ruff
         args: [--fix]

--- a/examples/objax_ft_safejax.py
+++ b/examples/objax_ft_safejax.py
@@ -1,0 +1,27 @@
+from jax import numpy as jnp
+from objax.zoo.resnet_v2 import ResNet50
+
+from safejax import deserialize, serialize
+
+model = ResNet50(in_channels=3, num_classes=1000)
+
+encoded_bytes = serialize(params=model.vars())
+assert isinstance(encoded_bytes, bytes)
+assert len(encoded_bytes) > 0
+
+decoded_params = deserialize(
+    encoded_bytes, requires_unflattening=False, to_var_collection=True
+)
+assert isinstance(decoded_params, dict)
+assert len(decoded_params) > 0
+assert decoded_params.keys() == model.vars().keys()
+
+for key, value in decoded_params.items():
+    if key not in model.vars():
+        print(f"Key {key} not in model.vars()! Skipping.")
+        continue
+    model.vars()[key].assign(value)
+
+x = jnp.ones((1, 3, 224, 224))
+y = model(x, training=False)
+assert y.shape == (1, 1000)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ path = "src/safejax/__init__.py"
 [project.optional-dependencies]
 quality = [
   "black~=22.10.0",
-  "ruff~=0.0.192",
+  "ruff~=0.0.194",
   "pre-commit~=2.20.0",
 ]
 tests = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,11 @@ classifiers = [
 dependencies = [
   "jaxlib~=0.3.25",
   "jax~=0.3.25",
+  "objax~=1.6.0",
   "flax~=0.6.2",
   "safetensors~=0.2.5",
 ]
-description = "Serialize JAX, Flax, or Haiku model params with `safetensors`"
+description = "Serialize JAX, Flax, Haiku, or Objax model params with `safetensors`"
 dynamic = ["version"]
 keywords = []
 license = "MIT"

--- a/src/safejax/__init__.py
+++ b/src/safejax/__init__.py
@@ -1,4 +1,4 @@
-"""`safejax `: Serialize JAX, Flax, or Haiku model params with `safetensors`"""
+"""`safejax `: Serialize JAX, Flax, Haiku, or Objax model params with `safetensors`"""
 
 __author__ = "Alvaro Bartolome <alvarobartt@yahoo.com>"
 __version__ = "0.3.0"

--- a/src/safejax/__init__.py
+++ b/src/safejax/__init__.py
@@ -1,7 +1,7 @@
 """`safejax `: Serialize JAX, Flax, or Haiku model params with `safetensors`"""
 
 __author__ = "Alvaro Bartolome <alvarobartt@yahoo.com>"
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 from safejax.load import deserialize  # noqa: F401
 from safejax.save import serialize  # noqa: F401

--- a/src/safejax/load.py
+++ b/src/safejax/load.py
@@ -51,7 +51,7 @@ def deserialize(
     ):
         decoded_params = load_file(filename=path_or_buf)
     if requires_unflattening:
-        decoded_params = unflatten_dict(tensors=decoded_params)
+        decoded_params = unflatten_dict(params=decoded_params)
     if freeze_dict:
         return freeze(decoded_params)
     if to_var_collection:

--- a/src/safejax/load.py
+++ b/src/safejax/load.py
@@ -1,8 +1,10 @@
 import os
 from pathlib import Path
-from typing import Union
+from typing import Dict, Union
 
 from flax.core.frozen_dict import FrozenDict, freeze
+from jax import numpy as jnp
+from objax.variable import VarCollection
 from safetensors.flax import load, load_file
 
 from safejax.typing import PathLike
@@ -10,19 +12,35 @@ from safejax.utils import unflatten_dict
 
 
 def deserialize(
-    path_or_buf: Union[PathLike, bytes], freeze_dict: bool = False
-) -> FrozenDict:
+    path_or_buf: Union[PathLike, bytes],
+    freeze_dict: bool = False,
+    requires_unflattening: bool = True,
+    to_var_collection: bool = False,
+) -> Union[FrozenDict, Dict[str, jnp.DeviceArray], VarCollection]:
     """
-    Deserialize a JAX, Haiku, or Flax model params from either a `bytes` object or a file path,
+    Deserialize JAX, Flax, Haiku, or Objax model params from either a `bytes` object or a file path,
     stored using `safetensors.flax.save_file` or directly saved using `safejax.save.serialize` with
     the `filename` parameter.
 
+    Note:
+        The default behavior of this function is to restore a `Dict[str, jnp.DeviceArray]` from
+        a `bytes` object or a file path. If you are using `objax`, you should set `requires_unflattening`
+        to `False` and `to_var_collection` to `True` to restore a `VarCollection`. If you're using `flax` you
+        should set `freeze_dict` to `True` to restore a `FrozenDict`. Those are just tips on how to use it
+        but all those frameworks are compatible with the default behavior.
+
     Args:
-        path_or_buf: A `bytes` object or a file path containing the serialized model params.
-        freeze_dict: Whether to freeze the output `Dict` to be a `FrozenDict` or not.
+        path_or_buf:
+            A `bytes` object or a file path containing the serialized model params.
+        freeze_dict:
+            Whether to freeze the output `Dict` to be a `FrozenDict` or not. Defaults to `False`.
+        requires_unflattening:
+            Whether the model params require unflattening or not. Defaults to `True`.
+        to_var_collection:
+            Whether to convert the output `Dict` to a `VarCollection` or not. Defaults to `False`.
 
     Returns:
-        An unflattened `Dict` or `FrozenDict` containing the model params.
+        A `Dict[str, jnp.DeviceArray]`, `FrozenDict`, or `VarCollection` containing the model params.
     """
     if isinstance(path_or_buf, bytes):
         decoded_params = load(data=path_or_buf)
@@ -32,5 +50,10 @@ def deserialize(
         or isinstance(path_or_buf, os.PathLike)
     ):
         decoded_params = load_file(filename=path_or_buf)
-    decoded_params_dict = unflatten_dict(tensors=decoded_params)
-    return freeze(decoded_params_dict) if freeze_dict else decoded_params_dict
+    if requires_unflattening:
+        decoded_params = unflatten_dict(tensors=decoded_params)
+    if freeze_dict:
+        return freeze(decoded_params)
+    if to_var_collection:
+        return VarCollection(decoded_params)
+    return decoded_params

--- a/src/safejax/save.py
+++ b/src/safejax/save.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Union
 
 from flax.core.frozen_dict import FrozenDict
+from objax.variable import VarCollection
 from safetensors.flax import save, save_file
 
 from safejax.typing import PathLike
@@ -8,25 +9,24 @@ from safejax.utils import flatten_dict
 
 
 def serialize(
-    params: Union[Dict[str, Any], FrozenDict],
+    params: Union[Dict[str, Any], FrozenDict, VarCollection],
     filename: Union[PathLike, None] = None,
 ) -> Union[bytes, PathLike]:
     """
-    Serialize a JAX/Flax/Haiku model params from either a `FrozenDict` or a `Dict`.
+    Serialize JAX, Flax, Haiku, or Objax model params from either `FrozenDict`, `Dict`, or `VarCollection`.
 
     If `filename` is not provided, the serialized model is returned as a `bytes` object,
     otherwise the model is saved to the provided `filename` and the `filename` is returned.
 
     Args:
-        params: A `FrozenDict` or a `Dict` containing the model params.
-        filename: The path to the file where the model will be saved.
+        params: A `FrozenDict`, a `Dict` or a `VarCollection` containing the model params.
+        filename: The path to the file where the model params will be saved.
 
     Returns:
-        The serialized model as a `bytes` object or the path to the file where the model was saved.
+        The serialized model params as a `bytes` object or the path to the file where the model params were saved.
     """
-    flattened_dict = flatten_dict(params=params)
-    if not filename:
-        return save(tensors=flattened_dict)
-    else:
-        save_file(tensors=flattened_dict, filename=filename)
+    params = flatten_dict(params=params)
+    if filename:
+        save_file(tensors=params, filename=filename)
         return filename
+    return save(tensors=params)

--- a/src/safejax/utils.py
+++ b/src/safejax/utils.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Union
 import numpy as np
 from flax.core.frozen_dict import FrozenDict
 from jax import numpy as jnp
+from objax.variable import BaseState, BaseVar
 
 
 def flatten_dict(
@@ -30,6 +31,8 @@ def flatten_dict(
     flattened_params = {}
     for key, value in params.items():
         key = f"{key_prefix}.{key}" if key_prefix else key
+        if isinstance(value, (BaseVar, BaseState)):
+            value = value.value
         if isinstance(value, (jnp.DeviceArray, np.ndarray)):
             flattened_params[key] = value
             continue

--- a/src/safejax/utils.py
+++ b/src/safejax/utils.py
@@ -46,23 +46,24 @@ def flatten_dict(
     return flattened_params
 
 
-def unflatten_dict(tensors: Dict[str, Any]) -> Dict[str, Any]:
+def unflatten_dict(params: Dict[str, Any]) -> Dict[str, Any]:
     """
-    Unflatten a `Dict` of tensors stored as a flattened dictionary.
+    Unflatten a `Dict` where the keys should be expanded using the `.` character
+    as a separator.
 
     Reference at https://stackoverflow.com/a/63545677.
 
     Args:
-        tensors: A `Dict` of tensors stored as a flattened dictionary.
+        params: A `Dict` containing the params to unflatten by expanding the keys.
 
     Returns:
-        An unflattened `Dict` of tensors.
+        An unflattened `Dict` where the keys are expanded using the `.` character.
     """
-    params = {}
-    for key, value in tensors.items():
-        params_tmp = params
+    unflattened_params = {}
+    for key, value in params.items():
+        unflattened_params_tmp = unflattened_params
         subkeys = key.split(".")
         for subkey in subkeys[:-1]:
-            params_tmp = params_tmp.setdefault(subkey, {})
-        params_tmp[subkeys[-1]] = value
-    return params
+            unflattened_params_tmp = unflattened_params_tmp.setdefault(subkey, {})
+        unflattened_params_tmp[subkeys[-1]] = value
+    return unflattened_params

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,7 +52,7 @@ from safejax.utils import flatten_dict, unflatten_dict
 def test_unflatten_dict(
     input_dict: Dict[str, Any], expected_output_dict: Dict[str, Any]
 ) -> None:
-    unflattened_dict = unflatten_dict(tensors=input_dict)
+    unflattened_dict = unflatten_dict(params=input_dict)
     assert unflattened_dict == expected_output_dict
 
 


### PR DESCRIPTION
## ✨ Features

- Add `objax` support for both `safejax.serialize` and `safejax.deserialize`
- Add `examples/objax_ft_safejax.py`
- Update docstrings as `objax` is now supported
- Rename `unflatten_dict` param `tensors` to `params` for readability