### PR TITLE
✏️ Add `DictionaryLike` type in `safejax.typing`

### DIFF
--- a/src/safejax/load.py
+++ b/src/safejax/load.py
@@ -1,13 +1,12 @@
 import os
 from pathlib import Path
-from typing import Dict, Union
+from typing import Union
 
-from flax.core.frozen_dict import FrozenDict, freeze
-from jax import numpy as jnp
+from flax.core.frozen_dict import freeze
 from objax.variable import VarCollection
 from safetensors.flax import load, load_file
 
-from safejax.typing import PathLike
+from safejax.typing import DictionaryLike, PathLike
 from safejax.utils import unflatten_dict
 
 
@@ -16,7 +15,7 @@ def deserialize(
     freeze_dict: bool = False,
     requires_unflattening: bool = True,
     to_var_collection: bool = False,
-) -> Union[FrozenDict, Dict[str, jnp.DeviceArray], VarCollection]:
+) -> DictionaryLike:
     """
     Deserialize JAX, Flax, Haiku, or Objax model params from either a `bytes` object or a file path,
     stored using `safetensors.flax.save_file` or directly saved using `safejax.save.serialize` with

--- a/src/safejax/save.py
+++ b/src/safejax/save.py
@@ -1,15 +1,13 @@
-from typing import Any, Dict, Union
+from typing import Union
 
-from flax.core.frozen_dict import FrozenDict
-from objax.variable import VarCollection
 from safetensors.flax import save, save_file
 
-from safejax.typing import PathLike
+from safejax.typing import DictionaryLike, PathLike
 from safejax.utils import flatten_dict
 
 
 def serialize(
-    params: Union[Dict[str, Any], FrozenDict, VarCollection],
+    params: DictionaryLike,
     filename: Union[PathLike, None] = None,
 ) -> Union[bytes, PathLike]:
     """

--- a/src/safejax/typing.py
+++ b/src/safejax/typing.py
@@ -1,6 +1,14 @@
 # Reference from https://github.com/huggingface/datasets/blob/main/src/datasets/utils/typing.py
 import os
 from pathlib import Path
-from typing import Union
+from typing import Dict, Union
+
+import numpy as np
+from flax.core.frozen_dict import FrozenDict
+from jax import numpy as jnp
+from objax.variable import VarCollection
 
 PathLike = Union[str, Path, os.PathLike]
+DictionaryLike = Union[
+    Dict[str, np.ndarray], Dict[str, jnp.DeviceArray], FrozenDict, VarCollection
+]

--- a/src/safejax/utils.py
+++ b/src/safejax/utils.py
@@ -5,13 +5,15 @@ from flax.core.frozen_dict import FrozenDict
 from jax import numpy as jnp
 from objax.variable import BaseState, BaseVar
 
+from safejax.typing import DictionaryLike
+
 
 def flatten_dict(
-    params: Union[Dict[str, Any], FrozenDict],
+    params: DictionaryLike,
     key_prefix: Union[str, None] = None,
-) -> Dict[str, Any]:
+) -> Union[Dict[str, np.ndarray], Dict[str, jnp.DeviceArray]]:
     """
-    Flatten a `FrozenDict` or a `Dict` containing either `jnp.DeviceArray` or
+    Flatten a `Dict`, `FrozenDict`, or `VarCollection` containing either `jnp.DeviceArray` or
     `np.ndarray` as values.
 
     Note:
@@ -22,11 +24,11 @@ def flatten_dict(
     Reference at https://gist.github.com/Narsil/d5b0d747e5c8c299eb6d82709e480e3d
 
     Args:
-        params: A `FrozenDict` or a `Dict` with the params to flatten.
+        params: A `Dict`, `FrozenDict`, or `VarCollection` with the params to flatten.
         key_prefix: A prefix to prepend to the keys of the flattened dictionary.
 
     Returns:
-        A `Dict` containing the flattened params.
+        A `Dict` containing the flattened params as level-1 key-value pairs.
     """
     flattened_params = {}
     for key, value in params.items():


### PR DESCRIPTION
## ✨ Features

- Add `DictionaryLike` type in `safejax.typing`
- Update `safejax` docstrings accordingly