### PR TITLE
♻️ Refactor on how `safejax` is structured

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -59,7 +59,7 @@ jobs:
           pip install ".[tests]"
 
       - name: run-tests
-        run: pytest tests/ -s --durations 0
+        run: pytest tests/ -s --durations 0 --disable-warnings
 
   deploy-docs:
     needs: run-tests

--- a/README.md
+++ b/README.md
@@ -134,7 +134,27 @@ pip install safejax --upgrade
   model(...)
   ```
 
+* Convert `params` to `bytes` in `params.safetensors` and assign during deserialization
+
+  ```python
+  from safejax.objax import serialize, deserialize_with_assignment
+
+  params = model.vars()
+
+  encoded_bytes = serialize(params=params, filename="./params.safetensors")
+  deserialize_with_assignment(filename="./params.safetensors", model_vars=params)
+
+  model(...)
+  ```
+
 ---
+
+📌 As you may have seen in the examples above, most of those codeblocks are imporing both
+`serialize` and `deserialize` from `safejax`, but as some of those expect params with respect
+to the JAX framework that we're using, we can just import those from their files to avoid 
+defining the params over and over e.g. instead of `from safejax import deserialize, serialize`,
+we can just import `from safejax.flax import deserialize, serialize`, and skip the function 
+params, so that the only input param that we need to provide are the params themselves.
 
 More in-detail examples can be found at [`examples/`](./examples) for `flax`, `dm-haiku`, and `objax`.
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 `safejax` is a Python package to serialize JAX, Flax, Haiku, or Objax model params using `safetensors`
 as the tensor storage format, instead of relying on `pickle`. For more details on why
-`safetensors` is safer than `pickle` please check [huggingface/tensors](https://github.com/huggingface/safetensors).
+`safetensors` is safer than `pickle` please check [huggingface/safetensors](https://github.com/huggingface/safetensors).
 
 Note that `safejax` supports the serialization of `jax`, `flax`, `dm-haiku`, and `objax` model
 parameters and has been tested with all those frameworks, but there may be some cases where it
 does not work as expected, as this is still in an early development phase, so please if you have
-any feedback or bug reports, please open an issue at [safejax/issues](https://github.com/alvarobartt/safejax/issues).
+any feedback or bug reports, open an issue at [safejax/issues](https://github.com/alvarobartt/safejax/issues).
 
 ## 🛠️ Requirements & Installation
 
@@ -144,25 +144,33 @@ More in-detail examples can be found at [`examples/`](./examples) for `flax`, `d
 while `pickle` has some known weaknesses and security issues. `safetensors`
 is also a storage format that is intended to be trivial to the framework
 used to load the tensors. More in-depth information can be found at 
-https://github.com/huggingface/safetensors.
+[huggingface/safetensors](https://github.com/huggingface/safetensors).
 
-Both `jax` and `haiku` use `pytrees` to store the model parameters in memory, so
+`jax` uses `pytrees` to store the model parameters in memory, so
 it's a dictionary-like class containing nested `jnp.DeviceArray` tensors.
 
-Then `objax` defines a custom dictionary-like class named `VarCollection` that contains
+`dm-haiku` uses a custom dictionary formatted as `<level_1>/~/<level_2>`, where the
+levels are the ones that define the tree structure and `/~/` is the separator between those
+e.g. `res_net50/~/intial_conv`, and that key does not contain a `jnp.DeviceArray`, but a 
+dictionary with key value pairs e.g. for both weights as `w` and biases as `b`.
+
+`objax` defines a custom dictionary-like class named `VarCollection` that contains
 some variables inheriting from `BaseVar` which is another custom `objax` type.
 
 `flax` defines a dictionary-like class named `FrozenDict` that is used to
 store the tensors in memory, it can be dumped either into `bytes` in `MessagePack`
 format or as a `state_dict`.
 
-Anyway, `flax` still uses `pickle` as the format for storing the tensors, so 
-there are no plans from HuggingFace to extend `safetensors` to support anything
-more than tensors e.g. `FrozenDict`s, see their response at
-https://github.com/huggingface/safetensors/discussions/138.
+Of all those, `flax` is the only framework that defines its custom functions to
+serialize and deserialize the model params under `flax.serialization`.But `flax` still
+uses `pickle` as the format for storing the tensors, and there are no plans from HuggingFace
+to extend `safetensors` to support anything more than tensors e.g. `FrozenDict`s, see their
+response at [huggingface/safetensors/discussions/138](https://github.com/huggingface/safetensors/discussions/138).
 
-So `safejax` was created to easily provide a way to serialize `FrozenDict`s
-using `safetensors` as the tensor storage format instead of `pickle`.
+So the motivation to create `safejax` is to easily provide a way to serialize `FrozenDict`s
+using `safetensors` as the tensor storage format instead of `pickle`, as well as to provide
+a common and easy way to serialize and deserialize any JAX model params (Flax, Haiku, or Objax)
+using `safetensors` format.
 
 ### 📄 Main differences with `flax.serialization`
 

--- a/docs/api/core_load.md
+++ b/docs/api/core_load.md
@@ -1,0 +1,2 @@
+::: safejax.core.load
+    handler: python

--- a/docs/api/core_save.md
+++ b/docs/api/core_save.md
@@ -1,0 +1,2 @@
+::: safejax.core.save
+    handler: python

--- a/docs/api/load.md
+++ b/docs/api/load.md
@@ -1,2 +1,0 @@
-::: safejax.load
-    handler: python

--- a/docs/api/save.md
+++ b/docs/api/save.md
@@ -1,2 +1,0 @@
-::: safejax.save
-    handler: python

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,0 +1,2 @@
+::: safejax.utils
+    handler: python

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,9 @@
 
 `safejax` is a Python package to serialize JAX, Flax, Haiku, or Objax model params using `safetensors`
 as the tensor storage format, instead of relying on `pickle`. For more details on why
-`safetensors` is safer than `pickle` please check https://github.com/huggingface/safetensors.
+`safetensors` is safer than `pickle` please check [huggingface/safetensors](https://github.com/huggingface/safetensors).
 
 Note that `safejax` supports the serialization of `jax`, `flax`, `dm-haiku`, and `objax` model
 parameters and has been tested with all those frameworks, but there may be some cases where it
 does not work as expected, as this is still in an early development phase, so please if you have
-any feedback or bug reports, open an issue at https://github.com/alvarobartt/safejax/issues
+any feedback or bug reports, open an issue at [safejax/issues](https://github.com/alvarobartt/safejax/issues).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -115,7 +115,27 @@
   model(...)
   ```
 
+* Convert `params` to `bytes` in `params.safetensors` and assign during deserialization
+
+  ```python
+  from safejax.objax import serialize, deserialize_with_assignment
+
+  params = model.vars()
+
+  encoded_bytes = serialize(params=params, filename="./params.safetensors")
+  deserialize_with_assignment(filename="./params.safetensors", model_vars=params)
+
+  model(...)
+  ```
+
 ---
+
+📌 As you may have seen in the examples above, most of those codeblocks are imporing both
+`serialize` and `deserialize` from `safejax`, but as some of those expect params with respect
+to the JAX framework that we're using, we can just import those from their files to avoid 
+defining the params over and over e.g. instead of `from safejax import deserialize, serialize`,
+we can just import `from safejax.flax import deserialize, serialize`, and skip the function 
+params, so that the only input param that we need to provide are the params themselves.
 
 More in-detail examples can be found at [`examples/`](https://github.com/alvarobartt/safejax/examples)
 for `flax`, `dm-haiku`, and `objax`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -117,4 +117,5 @@
 
 ---
 
-More in-detail examples can be found at [`examples/`](./examples) for `flax`, `dm-haiku`, and `objax`.
+More in-detail examples can be found at [`examples/`](https://github.com/alvarobartt/safejax/examples)
+for `flax`, `dm-haiku`, and `objax`.

--- a/docs/why_safejax.md
+++ b/docs/why_safejax.md
@@ -4,29 +4,30 @@
 while `pickle` has some known weaknesses and security issues. `safetensors`
 is also a storage format that is intended to be trivial to the framework
 used to load the tensors. More in-depth information can be found at 
-https://github.com/huggingface/safetensors.
+[huggingface/safetensors](https://github.com/huggingface/safetensors).
 
-Both `jax` and `haiku` use `pytrees` to store the model parameters in memory, so
+`jax` uses `pytrees` to store the model parameters in memory, so
 it's a dictionary-like class containing nested `jnp.DeviceArray` tensors.
 
-Then `objax` defines a custom dictionary-like class named `VarCollection` that contains
+`dm-haiku` uses a custom dictionary formatted as `<level_1>/~/<level_2>`, where the
+levels are the ones that define the tree structure and `/~/` is the separator between those
+e.g. `res_net50/~/intial_conv`, and that key does not contain a `jnp.DeviceArray`, but a 
+dictionary with key value pairs e.g. for both weights as `w` and biases as `b`.
+
+`objax` defines a custom dictionary-like class named `VarCollection` that contains
 some variables inheriting from `BaseVar` which is another custom `objax` type.
 
 `flax` defines a dictionary-like class named `FrozenDict` that is used to
 store the tensors in memory, it can be dumped either into `bytes` in `MessagePack`
 format or as a `state_dict`.
 
-Anyway, `flax` still uses `pickle` as the format for storing the tensors, so 
-there are no plans from HuggingFace to extend `safetensors` to support anything
-more than tensors e.g. `FrozenDict`s, see their response at
-https://github.com/huggingface/safetensors/discussions/138.
+Of all those, `flax` is the only framework that defines its custom functions to
+serialize and deserialize the model params under `flax.serialization`.But `flax` still
+uses `pickle` as the format for storing the tensors, and there are no plans from HuggingFace
+to extend `safetensors` to support anything more than tensors e.g. `FrozenDict`s, see their
+response at [huggingface/safetensors/discussions/138](https://github.com/huggingface/safetensors/discussions/138).
 
-So `safejax` was created to easily provide a way to serialize `FrozenDict`s
-using `safetensors` as the tensor storage format instead of `pickle`.
-
-## 📄 Main differences with `flax.serialization`
-
-* `flax.serialization.to_bytes` uses `pickle` as the tensor storage format, while
-`safejax.serialize` uses `safetensors`
-* `flax.serialization.from_bytes` requires the `target` to be instantiated, while
-`safejax.deserialize` just needs the encoded bytes
+So the motivation to create `safejax` is to easily provide a way to serialize `FrozenDict`s
+using `safetensors` as the tensor storage format instead of `pickle`, as well as to provide
+a common and easy way to serialize and deserialize any JAX model params (Flax, Haiku, or Objax)
+using `safetensors` format.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
   - Why safejax?: why_safejax.md
   - Examples: examples.md
   - Reference:
-      - safejax.load: api/load.md
-      - safejax.save: api/save.md
+      - safejax.core.load: api/core_load.md
+      - safejax.core.save: api/core_save.md
+      - safejax.utils: api/utils.md
   - License: license.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ features = [
 ]
 
 [tool.hatch.envs.test.scripts]
-run = "pytest tests/ --durations 0 -s"
+run = "pytest -s --durations 0 --disable-warnings"
 
 [[tool.hatch.envs.test.matrix]]
 python = ["37", "38", "39", "310"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,11 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: Implementation :: CPython",
-  "Programming Language :: Python :: Implementation :: PyPy",
+  "Programming Language :: Python :: 3.11",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
   "jaxlib~=0.3.25",
@@ -121,7 +124,6 @@ serve = [
 exclude = [
   "/.github",
   "/docs",
-  "/.devcontainer",
   "/.pre-commit-config.yaml",
   "/.gitignore",
   "/tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "jax~=0.3.25",
   "objax~=1.6.0",
   "flax~=0.6.2",
+  "dm-haiku~=0.0.9",
   "safetensors~=0.2.5",
 ]
 description = "Serialize JAX, Flax, Haiku, or Objax model params with `safetensors`"

--- a/src/safejax/__init__.py
+++ b/src/safejax/__init__.py
@@ -3,5 +3,5 @@
 __author__ = "Alvaro Bartolome <alvarobartt@yahoo.com>"
 __version__ = "0.3.0"
 
-from safejax.load import deserialize  # noqa: F401
-from safejax.save import serialize  # noqa: F401
+from safejax.core.load import deserialize  # noqa: F401
+from safejax.core.save import serialize  # noqa: F401

--- a/src/safejax/flax.py
+++ b/src/safejax/flax.py
@@ -1,0 +1,9 @@
+from functools import partial
+
+from safejax.core.load import deserialize
+from safejax.core.save import serialize  # noqa: F401
+
+# `flax` expects either a `Dict[str, Any` or a `FrozenDict`, but for robustness we are
+# setting `freeze_dict` to `True` to restore a `FrozenDict` which contains the params
+# frozen to avoid any accidental mutation.
+deserialize = partial(deserialize, freeze_dict=True)

--- a/src/safejax/haiku.py
+++ b/src/safejax/haiku.py
@@ -1,0 +1,6 @@
+from safejax.core.load import deserialize  # noqa: F401
+from safejax.core.save import serialize  # noqa: F401
+
+# Nothing here as `dm-haiku` works with the default behavior of both
+# `safejax.core.load.deserialize` and `safejax.core.save.serialize`. But
+# placing this here for consistency with the other frameworks.

--- a/src/safejax/objax.py
+++ b/src/safejax/objax.py
@@ -1,0 +1,9 @@
+from functools import partial
+
+from safejax.core.load import deserialize
+from safejax.core.save import serialize  # noqa: F401
+
+# `objax` expects either a `Dict[str, jnp.DeviceArray]` or a `VarCollection` as model params
+# which means any other type of `Dict` will not work. This is why we need to set `requires_unflattening`
+# to `False` and `to_var_collection` to `True` to restore a `VarCollection`, but the later could be skipped.
+deserialize = partial(deserialize, requires_unflattening=False, to_var_collection=True)

--- a/src/safejax/objax.py
+++ b/src/safejax/objax.py
@@ -1,9 +1,32 @@
 from functools import partial
+from pathlib import Path
+
+from objax.variable import VarCollection
+from safetensors import safe_open
 
 from safejax.core.load import deserialize
 from safejax.core.save import serialize  # noqa: F401
+from safejax.typing import PathLike
 
 # `objax` expects either a `Dict[str, jnp.DeviceArray]` or a `VarCollection` as model params
 # which means any other type of `Dict` will not work. This is why we need to set `requires_unflattening`
 # to `False` and `to_var_collection` to `True` to restore a `VarCollection`, but the later could be skipped.
 deserialize = partial(deserialize, requires_unflattening=False, to_var_collection=True)
+
+
+def deserialize_with_assignment(
+    filename: PathLike, model_vars: VarCollection
+) -> VarCollection:
+    if not isinstance(filename, (str, Path)):
+        raise ValueError(
+            "`filename` must be a `str` or a `pathlib.Path` object, not"
+            f" {type(filename)}."
+        )
+    filename = filename if isinstance(filename, Path) else Path(filename)
+    if not filename.exists or not filename.is_file:
+        raise ValueError(f"`filename` must be a valid file path, not {filename}.")
+    with safe_open(filename.as_posix(), framework="jax") as f:
+        for k in f.keys():
+            if k not in model_vars.keys():
+                raise ValueError(f"Variable with name {k} not found in model_vars.")
+            model_vars.vars()[k].assign(f.get_tensor(k))

--- a/src/safejax/objax.py
+++ b/src/safejax/objax.py
@@ -14,9 +14,23 @@ from safejax.typing import PathLike
 deserialize = partial(deserialize, requires_unflattening=False, to_var_collection=True)
 
 
-def deserialize_with_assignment(
-    filename: PathLike, model_vars: VarCollection
-) -> VarCollection:
+# When calling `deserialize` over an `objax.variable.VarCollection` object, those variables cannot
+# be used directly for the inference, as the forward pass in `objax` is done through `__call__`, which
+# implies that the class instance must contain the model params loaded in `.vars` attribute. So this
+# function has been created in order to ease the parameter loading for `objax`, since as opposed to
+# `flax` and `haiku`, the model params are not provided on every forward pass.
+def deserialize_with_assignment(filename: PathLike, model_vars: VarCollection) -> None:
+    """Deserialize a `VarCollection` from a file and assign it to a `VarCollection` object.
+
+    Args:
+        filename: Path to the file containing the serialized `VarCollection` as a `Dict[str, jnp.DeviceArray]`.
+        model_vars: `VarCollection` object to which the deserialized tensors will be assigned.
+
+    Returns:
+        `None`, as the deserialized tensors are assigned to the `model_vars` object. So you
+        just need to access `model_vars`, or the actual `model.vars()` attribute, since the
+        assignment is done over a class attribute named `vars`.
+    """
     if not isinstance(filename, (str, Path)):
         raise ValueError(
             "`filename` must be a `str` or a `pathlib.Path` object, not"

--- a/src/safejax/objax.py
+++ b/src/safejax/objax.py
@@ -29,4 +29,4 @@ def deserialize_with_assignment(
         for k in f.keys():
             if k not in model_vars.keys():
                 raise ValueError(f"Variable with name {k} not found in model_vars.")
-            model_vars.vars()[k].assign(f.get_tensor(k))
+            model_vars[k].assign(f.get_tensor(k))

--- a/src/safejax/typing.py
+++ b/src/safejax/typing.py
@@ -1,14 +1,15 @@
-# Reference from https://github.com/huggingface/datasets/blob/main/src/datasets/utils/typing.py
-import os
 from pathlib import Path
 from typing import Dict, Union
 
-import numpy as np
 from flax.core.frozen_dict import FrozenDict
 from jax import numpy as jnp
-from objax.variable import VarCollection
+from objax.variable import BaseVar, StateVar, VarCollection
 
-PathLike = Union[str, Path, os.PathLike]
-DictionaryLike = Union[
-    Dict[str, np.ndarray], Dict[str, jnp.DeviceArray], FrozenDict, VarCollection
-]
+PathLike = Union[str, Path]
+
+JaxDeviceArrayDict = Dict[str, jnp.DeviceArray]
+HaikuParams = Dict[str, JaxDeviceArrayDict]
+ObjaxParams = Union[VarCollection, Dict[str, Union[BaseVar, StateVar]]]
+FlaxParams = Union[Dict[str, Union[Dict, JaxDeviceArrayDict]], FrozenDict]
+
+ParamsDictLike = Union[JaxDeviceArrayDict, HaikuParams, ObjaxParams, FlaxParams]

--- a/src/safejax/utils.py
+++ b/src/safejax/utils.py
@@ -5,16 +5,16 @@ from flax.core.frozen_dict import FrozenDict
 from jax import numpy as jnp
 from objax.variable import BaseState, BaseVar
 
-from safejax.typing import DictionaryLike
+from safejax.typing import ParamsDictLike
 
 
 def flatten_dict(
-    params: DictionaryLike,
+    params: ParamsDictLike,
     key_prefix: Union[str, None] = None,
 ) -> Union[Dict[str, np.ndarray], Dict[str, jnp.DeviceArray]]:
     """
-    Flatten a `Dict`, `FrozenDict`, or `VarCollection` containing either `jnp.DeviceArray` or
-    `np.ndarray` as values.
+    Flatten a `Dict`, `FrozenDict`, or `VarCollection`, for more detailed information on
+    the supported input types check `safejax.typing.ParamsDictLike`.
 
     Note:
         This function is recursive to explore all the nested dictionaries,

--- a/src/safejax/utils.py
+++ b/src/safejax/utils.py
@@ -48,6 +48,9 @@ def flatten_dict(
     return flattened_params
 
 
+# Note that this function has a less restrictive type hint than the `flatten_dict` function.
+# This is because the `unflatten_dict` function is generic, and it can be used to unflatten
+# any `Dict` where the keys are expanded using the `.` character as a separator.
 def unflatten_dict(params: Dict[str, Any]) -> Dict[str, Any]:
     """
     Unflatten a `Dict` where the keys should be expanded using the `.` character

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,15 @@
 from pathlib import Path
 
+import haiku as hk
 import jax
 import jax.numpy as jnp
+import objax
 import pytest
 from flax import linen as nn
 from flax.core.frozen_dict import FrozenDict
-from flaxmodels.resnet import ResNet50
+from flaxmodels.resnet import ResNet50 as FlaxResNet50
+from objax.variable import VarCollection
+from objax.zoo.resnet_v2 import ResNet50 as ObjaxResNet50
 
 
 class SingleLayer(nn.Module):
@@ -31,18 +35,49 @@ def single_layer_params(single_layer: nn.Module) -> FrozenDict:
 
 
 @pytest.fixture
-def resnet50() -> nn.Module:
-    return ResNet50()
+def flax_resnet() -> nn.Module:
+    return FlaxResNet50()
 
 
 @pytest.fixture
-def resnet50_params(resnet50: nn.Module) -> FrozenDict:
+def flax_resnet50_params(flax_resnet: nn.Module) -> FrozenDict:
     rng = jax.random.PRNGKey(0)
-    params = resnet50.init(rng, jnp.ones((1, 224, 224, 3)))
+    params = flax_resnet.init(rng, jnp.ones((1, 224, 224, 3)))
     return params
+
+
+@pytest.fixture
+def haiku_resnet50() -> hk.TransformedWithState:
+    def resnet_fn(x: jnp.DeviceArray, is_training: bool) -> hk.Module:
+        resnet = hk.nets.ResNet50(num_classes=10)
+        return resnet(x, is_training=is_training)
+
+    return hk.without_apply_rng(hk.transform_with_state(resnet_fn))
+
+
+@pytest.fixture
+def haiku_resnet50_params(haiku_resnet50: hk.TransformedWithState) -> FrozenDict:
+    rng = jax.random.PRNGKey(0)
+    params, _ = haiku_resnet50.init(rng, jnp.ones((1, 224, 224, 3)), is_training=True)
+    return params
+
+
+@pytest.fixture
+def objax_resnet50() -> objax.nn.Sequential:
+    return ObjaxResNet50(in_channels=3, num_classes=1000)
+
+
+@pytest.fixture
+def objax_resnet50_params(objax_resnet50: objax.nn.Sequential) -> VarCollection:
+    return objax_resnet50.vars()
 
 
 @pytest.fixture(scope="session")
 def safetensors_file(tmp_path_factory) -> Path:
     # https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html#the-tmp-path-factory-fixture
-    return Path(tmp_path_factory.mktemp("data") / "model.safetensors")
+    return Path(tmp_path_factory.mktemp("data") / "params.safetensors")
+
+
+@pytest.fixture(scope="session")
+def msgpack_file(tmp_path_factory) -> Path:
+    return Path(tmp_path_factory.mktemp("data") / "params.msgpack")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,18 +12,15 @@ from objax.variable import VarCollection
 from objax.zoo.resnet_v2 import ResNet50 as ObjaxResNet50
 
 
-class SingleLayer(nn.Module):
-    features: int
-
-    @nn.compact
-    def __call__(self, x):
-        x = nn.Dense(features=self.features)(x)
-        return x
-
-
 @pytest.fixture
 def single_layer() -> nn.Module:
-    return SingleLayer(features=1)
+    class SingleLayer(nn.Module):
+        @nn.compact
+        def __call__(self, x):
+            x = nn.Dense(features=1)(x)
+            return x
+
+    return SingleLayer()
 
 
 @pytest.fixture
@@ -32,6 +29,21 @@ def single_layer_params(single_layer: nn.Module) -> FrozenDict:
     rng = jax.random.PRNGKey(0)
     params = single_layer.init(rng, jnp.ones((1, 1)))
     return params
+
+
+@pytest.fixture
+def objax_single_layer() -> objax.nn.Sequential:
+    return objax.nn.Sequential(
+        [
+            objax.nn.Linear(1, 1),
+        ]
+    )
+
+
+@pytest.fixture
+def objax_single_layer_params(objax_single_layer: objax.nn.Sequential) -> VarCollection:
+    # https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#fixtures-can-request-other-fixtures
+    return objax_single_layer.vars()
 
 
 @pytest.fixture

--- a/tests/test_core_load.py
+++ b/tests/test_core_load.py
@@ -3,8 +3,7 @@ from pathlib import Path
 import pytest
 from flax.core.frozen_dict import FrozenDict
 
-from safejax.load import deserialize
-from safejax.save import serialize
+from safejax import deserialize, serialize
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core_load.py
+++ b/tests/test_core_load.py
@@ -1,35 +1,80 @@
 from pathlib import Path
+from typing import Any, Dict, Union
 
 import pytest
 from flax.core.frozen_dict import FrozenDict
+from objax.variable import VarCollection
 
-from safejax import deserialize, serialize
+from safejax.core.load import deserialize
+from safejax.core.save import serialize
+from safejax.typing import ParamsDictLike
 
 
 @pytest.mark.parametrize(
-    "params",
+    "params, deserialize_kwargs, expected_output_type",
     [
-        pytest.lazy_fixture("single_layer_params"),
-        pytest.lazy_fixture("flax_resnet50_params"),
+        (
+            pytest.lazy_fixture("flax_resnet50_params"),
+            {"freeze_dict": True},
+            FrozenDict,
+        ),
+        (pytest.lazy_fixture("flax_resnet50_params"), {"freeze_dict": False}, dict),
+        (
+            pytest.lazy_fixture("objax_resnet50_params"),
+            {"requires_unflattening": False, "to_var_collection": True},
+            VarCollection,
+        ),
+        (
+            pytest.lazy_fixture("objax_resnet50_params"),
+            {"requires_unflattening": False, "to_var_collection": False},
+            dict,
+        ),
+        (pytest.lazy_fixture("haiku_resnet50_params"), {}, dict),
     ],
 )
-def test_deserialize(params: FrozenDict) -> None:
+def test_deserialize(
+    params: ParamsDictLike,
+    deserialize_kwargs: Dict[str, Any],
+    expected_output_type: Union[dict, FrozenDict, VarCollection],
+) -> None:
     encoded_params = serialize(params=params)
-    decoded_params = deserialize(path_or_buf=encoded_params, freeze_dict=True)
-    assert isinstance(decoded_params, FrozenDict)
+    decoded_params = deserialize(path_or_buf=encoded_params, **deserialize_kwargs)
+    assert isinstance(decoded_params, expected_output_type)
     assert len(decoded_params) > 0
+    assert decoded_params.keys() == params.keys()
 
 
 @pytest.mark.parametrize(
-    "params",
+    "params, deserialize_kwargs, expected_output_type",
     [
-        pytest.lazy_fixture("single_layer_params"),
-        pytest.lazy_fixture("flax_resnet50_params"),
+        (
+            pytest.lazy_fixture("flax_resnet50_params"),
+            {"freeze_dict": True},
+            FrozenDict,
+        ),
+        (pytest.lazy_fixture("flax_resnet50_params"), {"freeze_dict": False}, dict),
+        (
+            pytest.lazy_fixture("objax_resnet50_params"),
+            {"requires_unflattening": False, "to_var_collection": True},
+            VarCollection,
+        ),
+        (
+            pytest.lazy_fixture("objax_resnet50_params"),
+            {"requires_unflattening": False, "to_var_collection": False},
+            dict,
+        ),
+        (pytest.lazy_fixture("haiku_resnet50_params"), {}, dict),
     ],
 )
 @pytest.mark.usefixtures("safetensors_file")
-def test_deserialize_from_file(params: FrozenDict, safetensors_file: Path) -> None:
+def test_deserialize_from_file(
+    params: FrozenDict,
+    deserialize_kwargs: Dict[str, Any],
+    expected_output_type: Union[dict, FrozenDict, VarCollection],
+    safetensors_file: Path,
+) -> None:
     safetensors_file = serialize(params=params, filename=safetensors_file)
-    decoded_params = deserialize(path_or_buf=safetensors_file, freeze_dict=True)
-    assert isinstance(decoded_params, FrozenDict)
+    decoded_params = deserialize(path_or_buf=safetensors_file, **deserialize_kwargs)
+    assert isinstance(decoded_params, expected_output_type)
     assert len(decoded_params) > 0
+    assert decoded_params.keys() == params.keys()

--- a/tests/test_core_load.py
+++ b/tests/test_core_load.py
@@ -10,7 +10,7 @@ from safejax import deserialize, serialize
     "params",
     [
         pytest.lazy_fixture("single_layer_params"),
-        pytest.lazy_fixture("resnet50_params"),
+        pytest.lazy_fixture("flax_resnet50_params"),
     ],
 )
 def test_deserialize(params: FrozenDict) -> None:
@@ -24,7 +24,7 @@ def test_deserialize(params: FrozenDict) -> None:
     "params",
     [
         pytest.lazy_fixture("single_layer_params"),
-        pytest.lazy_fixture("resnet50_params"),
+        pytest.lazy_fixture("flax_resnet50_params"),
     ],
 )
 @pytest.mark.usefixtures("safetensors_file")

--- a/tests/test_core_load.py
+++ b/tests/test_core_load.py
@@ -41,6 +41,7 @@ def test_deserialize(
     decoded_params = deserialize(path_or_buf=encoded_params, **deserialize_kwargs)
     assert isinstance(decoded_params, expected_output_type)
     assert len(decoded_params) > 0
+    assert id(decoded_params) != id(params)
     assert decoded_params.keys() == params.keys()
 
 
@@ -77,4 +78,5 @@ def test_deserialize_from_file(
     decoded_params = deserialize(path_or_buf=safetensors_file, **deserialize_kwargs)
     assert isinstance(decoded_params, expected_output_type)
     assert len(decoded_params) > 0
+    assert id(decoded_params) != id(params)
     assert decoded_params.keys() == params.keys()

--- a/tests/test_core_save.py
+++ b/tests/test_core_save.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
 import pytest
-from flax.core.frozen_dict import FrozenDict
 
-from safejax import serialize
+from safejax.core.save import serialize
+from safejax.utils import ParamsDictLike
 
 
 @pytest.mark.parametrize(
@@ -11,9 +11,11 @@ from safejax import serialize
     [
         pytest.lazy_fixture("single_layer_params"),
         pytest.lazy_fixture("flax_resnet50_params"),
+        pytest.lazy_fixture("objax_resnet50_params"),
+        pytest.lazy_fixture("haiku_resnet50_params"),
     ],
 )
-def test_serialize(params: FrozenDict) -> None:
+def test_serialize(params: ParamsDictLike) -> None:
     encoded_params = serialize(params=params)
     assert isinstance(encoded_params, bytes)
     assert len(encoded_params) > 0
@@ -24,10 +26,12 @@ def test_serialize(params: FrozenDict) -> None:
     [
         pytest.lazy_fixture("single_layer_params"),
         pytest.lazy_fixture("flax_resnet50_params"),
+        pytest.lazy_fixture("objax_resnet50_params"),
+        pytest.lazy_fixture("haiku_resnet50_params"),
     ],
 )
 @pytest.mark.usefixtures("safetensors_file")
-def test_serialize_to_file(params: FrozenDict, safetensors_file: Path) -> None:
+def test_serialize_to_file(params: ParamsDictLike, safetensors_file: Path) -> None:
     safetensors_file = serialize(params=params, filename=safetensors_file)
     assert isinstance(safetensors_file, Path)
     assert safetensors_file.exists()

--- a/tests/test_core_save.py
+++ b/tests/test_core_save.py
@@ -10,7 +10,7 @@ from safejax import serialize
     "params",
     [
         pytest.lazy_fixture("single_layer_params"),
-        pytest.lazy_fixture("resnet50_params"),
+        pytest.lazy_fixture("flax_resnet50_params"),
     ],
 )
 def test_serialize(params: FrozenDict) -> None:
@@ -23,7 +23,7 @@ def test_serialize(params: FrozenDict) -> None:
     "params",
     [
         pytest.lazy_fixture("single_layer_params"),
-        pytest.lazy_fixture("resnet50_params"),
+        pytest.lazy_fixture("flax_resnet50_params"),
     ],
 )
 @pytest.mark.usefixtures("safetensors_file")

--- a/tests/test_core_save.py
+++ b/tests/test_core_save.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 from flax.core.frozen_dict import FrozenDict
 
-from safejax.save import serialize
+from safejax import serialize
 
 
 @pytest.mark.parametrize(

--- a/tests/test_flax.py
+++ b/tests/test_flax.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+import pytest
+from flax.core.frozen_dict import FrozenDict, freeze, unfreeze
+from flax.serialization import msgpack_restore, msgpack_serialize
+
+from safejax.flax import deserialize, serialize
+from safejax.typing import FlaxParams
+from safejax.utils import flatten_dict
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("single_layer_params"),
+        pytest.lazy_fixture("flax_resnet50_params"),
+    ],
+)
+def test_partial_deserialize(params: FlaxParams) -> None:
+    encoded_params = serialize(params=params)
+    decoded_params = deserialize(path_or_buf=encoded_params)
+    assert len(decoded_params) > 0
+    assert isinstance(decoded_params, FrozenDict)
+    assert decoded_params.keys() == params.keys()
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("single_layer_params"),
+        pytest.lazy_fixture("flax_resnet50_params"),
+    ],
+)
+@pytest.mark.usefixtures("safetensors_file")
+def test_partial_deserialize_from_file(
+    params: FlaxParams, safetensors_file: Path
+) -> None:
+    safetensors_file = serialize(params=params, filename=safetensors_file)
+    decoded_params = deserialize(path_or_buf=safetensors_file)
+    assert len(decoded_params) > 0
+    assert isinstance(decoded_params, FrozenDict)
+    assert decoded_params.keys() == params.keys()
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("single_layer_params"),
+        pytest.lazy_fixture("flax_resnet50_params"),
+    ],
+)
+@pytest.mark.usefixtures("safetensors_file", "msgpack_file")
+def test_safejax_versus_msgpack(
+    params: FlaxParams, safetensors_file: Path, msgpack_file: Path
+) -> None:
+    safetensors_file = serialize(params=params, filename=safetensors_file)
+    safetensors_decoded_params = deserialize(path_or_buf=safetensors_file)
+    assert len(safetensors_decoded_params) > 0
+    assert isinstance(safetensors_decoded_params, FrozenDict)
+    assert safetensors_decoded_params.keys() == params.keys()
+
+    with open(msgpack_file, mode="wb") as f:
+        f.write(msgpack_serialize(unfreeze(params)))
+
+    with open(msgpack_file, "rb") as f:
+        msgpack_decoded_params = freeze(msgpack_restore(f.read()))
+
+    assert len(msgpack_decoded_params) > 0
+    assert isinstance(msgpack_decoded_params, type(params))
+    assert msgpack_decoded_params.keys() == params.keys()
+
+    params = flatten_dict(params)
+    safetensors_decoded_params = flatten_dict(safetensors_decoded_params)
+    msgpack_decoded_params = flatten_dict(msgpack_decoded_params)
+    assert safetensors_decoded_params.keys() == msgpack_decoded_params.keys()
+    assert all(
+        safetensors_decoded_params[k].shape == msgpack_decoded_params[k].shape
+        for k in params.keys()
+    )

--- a/tests/test_flax.py
+++ b/tests/test_flax.py
@@ -2,7 +2,14 @@ from pathlib import Path
 
 import pytest
 from flax.core.frozen_dict import FrozenDict, freeze, unfreeze
-from flax.serialization import msgpack_restore, msgpack_serialize
+from flax.serialization import (
+    from_bytes,
+    from_state_dict,
+    msgpack_restore,
+    msgpack_serialize,
+    to_bytes,
+    to_state_dict,
+)
 
 from safejax.flax import deserialize, serialize
 from safejax.typing import FlaxParams
@@ -19,8 +26,9 @@ from safejax.utils import flatten_dict
 def test_partial_deserialize(params: FlaxParams) -> None:
     encoded_params = serialize(params=params)
     decoded_params = deserialize(path_or_buf=encoded_params)
-    assert len(decoded_params) > 0
     assert isinstance(decoded_params, FrozenDict)
+    assert len(decoded_params) > 0
+    assert id(decoded_params) != id(params)
     assert decoded_params.keys() == params.keys()
 
 
@@ -37,8 +45,9 @@ def test_partial_deserialize_from_file(
 ) -> None:
     safetensors_file = serialize(params=params, filename=safetensors_file)
     decoded_params = deserialize(path_or_buf=safetensors_file)
-    assert len(decoded_params) > 0
     assert isinstance(decoded_params, FrozenDict)
+    assert len(decoded_params) > 0
+    assert id(decoded_params) != id(params)
     assert decoded_params.keys() == params.keys()
 
 
@@ -50,13 +59,17 @@ def test_partial_deserialize_from_file(
     ],
 )
 @pytest.mark.usefixtures("safetensors_file", "msgpack_file")
-def test_safejax_versus_msgpack(
+def test_safejax_and_msgpack(
     params: FlaxParams, safetensors_file: Path, msgpack_file: Path
 ) -> None:
     safetensors_file = serialize(params=params, filename=safetensors_file)
+    assert isinstance(safetensors_file, Path)
+    assert safetensors_file.exists()
+
     safetensors_decoded_params = deserialize(path_or_buf=safetensors_file)
-    assert len(safetensors_decoded_params) > 0
     assert isinstance(safetensors_decoded_params, FrozenDict)
+    assert len(safetensors_decoded_params) > 0
+    assert id(safetensors_decoded_params) != id(params)
     assert safetensors_decoded_params.keys() == params.keys()
 
     with open(msgpack_file, mode="wb") as f:
@@ -65,8 +78,9 @@ def test_safejax_versus_msgpack(
     with open(msgpack_file, "rb") as f:
         msgpack_decoded_params = freeze(msgpack_restore(f.read()))
 
-    assert len(msgpack_decoded_params) > 0
     assert isinstance(msgpack_decoded_params, type(params))
+    assert len(msgpack_decoded_params) > 0
+    assert id(msgpack_decoded_params) != id(params)
     assert msgpack_decoded_params.keys() == params.keys()
 
     params = flatten_dict(params)
@@ -75,5 +89,83 @@ def test_safejax_versus_msgpack(
     assert safetensors_decoded_params.keys() == msgpack_decoded_params.keys()
     assert all(
         safetensors_decoded_params[k].shape == msgpack_decoded_params[k].shape
+        for k in params.keys()
+    )
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("single_layer_params"),
+        pytest.lazy_fixture("flax_resnet50_params"),
+    ],
+)
+def test_safejax_and_msgpack_bytes(params: FlaxParams) -> None:
+    encoded_params = serialize(params=params)
+    assert isinstance(encoded_params, bytes)
+    assert len(encoded_params) > 0
+
+    safetensors_decoded_params = deserialize(path_or_buf=encoded_params)
+    assert isinstance(safetensors_decoded_params, FrozenDict)
+    assert len(safetensors_decoded_params) > 0
+    assert id(safetensors_decoded_params) != id(params)
+    assert safetensors_decoded_params.keys() == params.keys()
+
+    msgpack_bytes_encoded_params = to_bytes(params)
+    assert isinstance(msgpack_bytes_encoded_params, bytes)
+    assert len(msgpack_bytes_encoded_params) > 0
+
+    msgpack_bytes_decoded_params = freeze(
+        from_bytes(params, msgpack_bytes_encoded_params)
+    )
+    assert isinstance(msgpack_bytes_decoded_params, FrozenDict)
+    assert len(msgpack_bytes_decoded_params) > 0
+    assert id(msgpack_bytes_decoded_params) != id(params)
+    assert msgpack_bytes_decoded_params.keys() == params.keys()
+
+    params = flatten_dict(params)
+    safetensors_decoded_params = flatten_dict(safetensors_decoded_params)
+    msgpack_bytes_decoded_params = flatten_dict(msgpack_bytes_decoded_params)
+    assert safetensors_decoded_params.keys() == msgpack_bytes_decoded_params.keys()
+    assert all(
+        safetensors_decoded_params[k].shape == msgpack_bytes_decoded_params[k].shape
+        for k in params.keys()
+    )
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("single_layer_params"),
+        # pytest.lazy_fixture("flax_resnet50_params"),
+    ],
+)
+def test_safejax_and_state_dict(params: FlaxParams) -> None:
+    encoded_params = serialize(params=params)
+    assert isinstance(encoded_params, bytes)
+    assert len(encoded_params) > 0
+
+    safetensors_decoded_params = deserialize(path_or_buf=encoded_params)
+    assert isinstance(safetensors_decoded_params, FrozenDict)
+    assert len(safetensors_decoded_params) > 0
+    assert id(safetensors_decoded_params) != id(params)
+    assert safetensors_decoded_params.keys() == params.keys()
+
+    state_dict_encoded_params = to_state_dict(params)
+    assert isinstance(state_dict_encoded_params, dict)
+    assert len(state_dict_encoded_params) > 0
+
+    state_dict_decoded_params = from_state_dict(params, state_dict_encoded_params)
+    assert isinstance(state_dict_decoded_params, FrozenDict)
+    assert len(state_dict_decoded_params) > 0
+    assert id(state_dict_decoded_params) != id(params)
+    assert state_dict_decoded_params.keys() == params.keys()
+
+    params = flatten_dict(params)
+    safetensors_decoded_params = flatten_dict(safetensors_decoded_params)
+    state_dict_decoded_params = flatten_dict(state_dict_decoded_params)
+    assert safetensors_decoded_params.keys() == state_dict_decoded_params.keys()
+    assert all(
+        safetensors_decoded_params[k].shape == state_dict_decoded_params[k].shape
         for k in params.keys()
     )

--- a/tests/test_haiku.py
+++ b/tests/test_haiku.py
@@ -20,6 +20,7 @@ def test_serialize_and_deserialize(params: HaikuParams) -> None:
     decoded_params = deserialize(path_or_buf=encoded_params)
     assert isinstance(decoded_params, dict)
     assert len(decoded_params) > 0
+    assert id(decoded_params) != id(params)
     assert decoded_params.keys() == params.keys()
 
 
@@ -40,4 +41,5 @@ def test_serialize_and_deserialize_from_file(
     decoded_params = deserialize(path_or_buf=safetensors_file)
     assert isinstance(decoded_params, dict)
     assert len(decoded_params) > 0
+    assert id(decoded_params) != id(params)
     assert decoded_params.keys() == params.keys()

--- a/tests/test_haiku.py
+++ b/tests/test_haiku.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import pytest
+
+from safejax.haiku import deserialize, serialize
+from safejax.typing import HaikuParams
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("haiku_resnet50_params"),
+    ],
+)
+def test_serialize_and_deserialize(params: HaikuParams) -> None:
+    encoded_params = serialize(params=params)
+    assert isinstance(encoded_params, bytes)
+    assert len(encoded_params) > 0
+
+    decoded_params = deserialize(path_or_buf=encoded_params)
+    assert isinstance(decoded_params, dict)
+    assert len(decoded_params) > 0
+    assert decoded_params.keys() == params.keys()
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("haiku_resnet50_params"),
+    ],
+)
+@pytest.mark.usefixtures("safetensors_file")
+def test_serialize_and_deserialize_from_file(
+    params: HaikuParams, safetensors_file: Path
+) -> None:
+    safetensors_file = serialize(params=params, filename=safetensors_file)
+    assert isinstance(safetensors_file, Path)
+    assert safetensors_file.exists()
+
+    decoded_params = deserialize(path_or_buf=safetensors_file)
+    assert isinstance(decoded_params, dict)
+    assert len(decoded_params) > 0
+    assert decoded_params.keys() == params.keys()

--- a/tests/test_objax.py
+++ b/tests/test_objax.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pytest
+from objax.variable import VarCollection
+
+from safejax.objax import deserialize, serialize
+from safejax.typing import ObjaxParams
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("objax_resnet50_params"),
+    ],
+)
+def test_serialize_and_deserialize(params: ObjaxParams) -> None:
+    encoded_params = serialize(params=params)
+    assert isinstance(encoded_params, bytes)
+    assert len(encoded_params) > 0
+
+    decoded_params = deserialize(path_or_buf=encoded_params)
+    assert isinstance(decoded_params, VarCollection)
+    assert len(decoded_params) > 0
+    assert decoded_params.keys() == params.keys()
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("objax_resnet50_params"),
+    ],
+)
+@pytest.mark.usefixtures("safetensors_file")
+def test_serialize_and_deserialize_from_file(
+    params: ObjaxParams, safetensors_file: Path
+) -> None:
+    safetensors_file = serialize(params=params, filename=safetensors_file)
+    assert isinstance(safetensors_file, Path)
+    assert safetensors_file.exists()
+
+    decoded_params = deserialize(path_or_buf=safetensors_file)
+    assert isinstance(decoded_params, VarCollection)
+    assert len(decoded_params) > 0
+    assert decoded_params.keys() == params.keys()

--- a/tests/test_objax.py
+++ b/tests/test_objax.py
@@ -1,15 +1,17 @@
 from pathlib import Path
 
 import pytest
+from jax import numpy as jnp
 from objax.variable import VarCollection
 
-from safejax.objax import deserialize, serialize
+from safejax.objax import deserialize, deserialize_with_assignment, serialize
 from safejax.typing import ObjaxParams
 
 
 @pytest.mark.parametrize(
     "params",
     [
+        pytest.lazy_fixture("objax_single_layer_params"),
         pytest.lazy_fixture("objax_resnet50_params"),
     ],
 )
@@ -21,12 +23,14 @@ def test_serialize_and_deserialize(params: ObjaxParams) -> None:
     decoded_params = deserialize(path_or_buf=encoded_params)
     assert isinstance(decoded_params, VarCollection)
     assert len(decoded_params) > 0
+    assert id(decoded_params) != id(params)
     assert decoded_params.keys() == params.keys()
 
 
 @pytest.mark.parametrize(
     "params",
     [
+        pytest.lazy_fixture("objax_single_layer_params"),
         pytest.lazy_fixture("objax_resnet50_params"),
     ],
 )
@@ -41,4 +45,31 @@ def test_serialize_and_deserialize_from_file(
     decoded_params = deserialize(path_or_buf=safetensors_file)
     assert isinstance(decoded_params, VarCollection)
     assert len(decoded_params) > 0
+    assert id(decoded_params) != id(params)
     assert decoded_params.keys() == params.keys()
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("objax_single_layer_params"),
+        pytest.lazy_fixture("objax_resnet50_params"),
+    ],
+)
+@pytest.mark.usefixtures("safetensors_file")
+def test_serialize_and_deserialize_with_assignment(
+    params: ObjaxParams, safetensors_file: Path
+) -> None:
+    safetensors_file = serialize(params=params, filename=safetensors_file)
+    assert isinstance(safetensors_file, Path)
+    assert safetensors_file.exists()
+
+    # Assign jnp.zeros to all params.tensors() to make sure the assignment is working
+    # before we deserialize the params.
+    params.assign([jnp.zeros(x.shape, x.dtype) for x in params.tensors()])
+    assert all([jnp.all(x == 0) for x in params.tensors()])
+
+    deserialize_with_assignment(filename=safetensors_file, model_vars=params)
+    assert isinstance(params, VarCollection)
+    assert len(params) > 0
+    assert not all([jnp.all(x != 0) for x in params.tensors()])


### PR DESCRIPTION
## ✨ Features

- Move both `load.py` and `save.py` to `safejax/core/`
- Add modules per framework (`flax`, `dm-haiku`, and `objax`) with `functools.partial` definitions to avoid having to include multiple params every time serialization/deserialization happens
- Add `safejax.objax.deserialize_with_assignment` to ease the param assignment after `deserialize` (uses `safe_open` internally, so currently it can just be used with `safetensors` files)

## 🐛 Bug Fixes

- Fix bug in `safejax.objax.deserialize_with_assignment`

## 📝 Documentation

- Update `README.md`
- Update `docs/`
- Add missing and new docstrings and code-comments

## 🔗 Linked Issue/s

The following issues are solved as part of this PR:
* #20 
* #18 
* #17 

## 🧪 Tests

- [X] Did you implement unit tests if required?

If the above checkbox is checked, describe how you unit-tested it.

* Add unit tests per framework i.e. `flax`, `dm-haiku`, and `objax`
* Add more assertions to ensure robustness
* Add some comparisons with `flax`'s default serialization methods (the other frameworks don't have a serialization standard)