### PR TITLE
🍱 Add support for `fsspec` file-systems

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,6 @@ Add here the reference to the issue/s referenced in this PR
 
 ## 🧪 Tests
 
-- [ ] Did you implement unit tests if required?
+- [ ] Did you implement unit tests if you need to?
 
-If the above checkbox is checked, describe how you unit-tested it.
+If the above checkbox is checked, could you describe how you unit-tested it?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "flax~=0.6.2",
   "dm-haiku~=0.0.9",
   "safetensors~=0.2.5",
+  "fsspec~=2022.11.0",
 ]
 description = "Serialize JAX, Flax, Haiku, or Objax model params with `safetensors`"
 dynamic = ["version"]

--- a/src/safejax/__init__.py
+++ b/src/safejax/__init__.py
@@ -1,7 +1,7 @@
 """`safejax `: Serialize JAX, Flax, Haiku, or Objax model params with `safetensors`"""
 
 __author__ = "Alvaro Bartolome <alvarobartt@yahoo.com>"
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 from safejax.core.load import deserialize  # noqa: F401
 from safejax.core.save import serialize  # noqa: F401

--- a/src/safejax/core/save.py
+++ b/src/safejax/core/save.py
@@ -1,6 +1,9 @@
+import os
+import tempfile
 from pathlib import Path
 from typing import Union
 
+from fsspec import AbstractFileSystem
 from safetensors.flax import save, save_file
 
 from safejax.typing import ParamsDictLike, PathLike
@@ -10,6 +13,7 @@ from safejax.utils import flatten_dict
 def serialize(
     params: ParamsDictLike,
     filename: Union[PathLike, None] = None,
+    fs: Union[AbstractFileSystem, None] = None,
 ) -> Union[bytes, PathLike]:
     """
     Serialize JAX, Flax, Haiku, or Objax model params from either `FrozenDict`, `Dict`, or `VarCollection`.
@@ -20,6 +24,7 @@ def serialize(
     Args:
         params: A `FrozenDict`, a `Dict` or a `VarCollection` containing the model params.
         filename: The path to the file where the model params will be saved.
+        fs: The filesystem to use to save the model params. Defaults to `None`.
 
     Returns:
         The serialized model params as a `bytes` object or the path to the file where the model params were saved.
@@ -32,10 +37,28 @@ def serialize(
                 "If `filename` is provided (not `None`), it must be a `str` or a"
                 f" `pathlib.Path` object, not {type(filename)}."
             )
-        filename = filename if isinstance(filename, Path) else Path(filename)
-        if not filename.exists or not filename.is_file:
-            raise ValueError(f"`filename` must be a valid file path, not {filename}.")
-        save_file(tensors=params, filename=filename.as_posix())
+        if fs and fs.protocol != "file":
+            if not isinstance(fs, AbstractFileSystem):
+                raise ValueError(
+                    "`fs` must be a `fsspec.AbstractFileSystem` object or `None`,"
+                    f" not {type(fs)}."
+                )
+            temp_filename = tempfile.NamedTemporaryFile(
+                mode="wb", suffix=".safetensors", delete=False
+            )
+            try:
+                temp_filename.write(save(tensors=params))
+            finally:
+                temp_filename.close()
+                fs.put_file(lpath=temp_filename.name, rpath=filename)
+                os.remove(temp_filename.name)
+        else:
+            filename = filename if isinstance(filename, Path) else Path(filename)
+            if not filename.exists or not filename.is_file:
+                raise ValueError(
+                    f"`filename` must be a valid file path, not {filename}."
+                )
+            save_file(tensors=params, filename=filename.as_posix())
         return filename
 
     return save(tensors=params)

--- a/src/safejax/core/save.py
+++ b/src/safejax/core/save.py
@@ -53,7 +53,10 @@ def serialize(
                 fs.put_file(lpath=temp_filename.name, rpath=filename)
                 os.remove(temp_filename.name)
         else:
-            filename = filename if isinstance(filename, Path) else Path(filename)
+            if fs and fs.protocol == "file":
+                filename = Path(fs._strip_protocol(filename))
+            else:
+                filename = filename if isinstance(filename, Path) else Path(filename)
             if not filename.exists or not filename.is_file:
                 raise ValueError(
                     f"`filename` must be a valid file path, not {filename}."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from objax.zoo.resnet_v2 import ResNet50 as ObjaxResNet50
 
 
 @pytest.fixture
-def single_layer() -> nn.Module:
+def flax_single_layer() -> nn.Module:
     class SingleLayer(nn.Module):
         @nn.compact
         def __call__(self, x):
@@ -24,10 +24,10 @@ def single_layer() -> nn.Module:
 
 
 @pytest.fixture
-def single_layer_params(single_layer: nn.Module) -> FrozenDict:
+def flax_single_layer_params(flax_single_layer: nn.Module) -> FrozenDict:
     # https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#fixtures-can-request-other-fixtures
     rng = jax.random.PRNGKey(0)
-    params = single_layer.init(rng, jnp.ones((1, 1)))
+    params = flax_single_layer.init(rng, jnp.ones((1, 1)))
     return params
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import fsspec
 import haiku as hk
 import jax
 import jax.numpy as jnp
@@ -8,6 +9,7 @@ import pytest
 from flax import linen as nn
 from flax.core.frozen_dict import FrozenDict
 from flaxmodels.resnet import ResNet50 as FlaxResNet50
+from fsspec.spec import AbstractFileSystem
 from objax.variable import VarCollection
 from objax.zoo.resnet_v2 import ResNet50 as ObjaxResNet50
 
@@ -93,3 +95,8 @@ def safetensors_file(tmp_path_factory) -> Path:
 @pytest.fixture(scope="session")
 def msgpack_file(tmp_path_factory) -> Path:
     return Path(tmp_path_factory.mktemp("data") / "params.msgpack")
+
+
+@pytest.fixture
+def fs() -> AbstractFileSystem:
+    return fsspec.filesystem("file")

--- a/tests/test_core_load.py
+++ b/tests/test_core_load.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Union
 
 import pytest
 from flax.core.frozen_dict import FrozenDict
+from fsspec.spec import AbstractFileSystem
 from objax.variable import VarCollection
 
 from safejax.core.load import deserialize
@@ -76,6 +77,46 @@ def test_deserialize_from_file(
 ) -> None:
     safetensors_file = serialize(params=params, filename=safetensors_file)
     decoded_params = deserialize(path_or_buf=safetensors_file, **deserialize_kwargs)
+    assert isinstance(decoded_params, expected_output_type)
+    assert len(decoded_params) > 0
+    assert id(decoded_params) != id(params)
+    assert decoded_params.keys() == params.keys()
+
+
+@pytest.mark.parametrize(
+    "params, deserialize_kwargs, expected_output_type",
+    [
+        (
+            pytest.lazy_fixture("flax_resnet50_params"),
+            {"freeze_dict": True},
+            FrozenDict,
+        ),
+        (pytest.lazy_fixture("flax_resnet50_params"), {"freeze_dict": False}, dict),
+        (
+            pytest.lazy_fixture("objax_resnet50_params"),
+            {"requires_unflattening": False, "to_var_collection": True},
+            VarCollection,
+        ),
+        (
+            pytest.lazy_fixture("objax_resnet50_params"),
+            {"requires_unflattening": False, "to_var_collection": False},
+            dict,
+        ),
+        (pytest.lazy_fixture("haiku_resnet50_params"), {}, dict),
+    ],
+)
+@pytest.mark.usefixtures("safetensors_file", "fs")
+def test_deserialize_from_file_in_fs(
+    params: FrozenDict,
+    deserialize_kwargs: Dict[str, Any],
+    expected_output_type: Union[dict, FrozenDict, VarCollection],
+    safetensors_file: Path,
+    fs: AbstractFileSystem,
+) -> None:
+    safetensors_file = serialize(params=params, filename=safetensors_file, fs=fs)
+    decoded_params = deserialize(
+        path_or_buf=safetensors_file, fs=fs, **deserialize_kwargs
+    )
     assert isinstance(decoded_params, expected_output_type)
     assert len(decoded_params) > 0
     assert id(decoded_params) != id(params)

--- a/tests/test_core_save.py
+++ b/tests/test_core_save.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from fsspec.spec import AbstractFileSystem
 
 from safejax.core.save import serialize
 from safejax.utils import ParamsDictLike
@@ -35,3 +36,22 @@ def test_serialize_to_file(params: ParamsDictLike, safetensors_file: Path) -> No
     safetensors_file = serialize(params=params, filename=safetensors_file)
     assert isinstance(safetensors_file, Path)
     assert safetensors_file.exists()
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("flax_single_layer_params"),
+        pytest.lazy_fixture("flax_resnet50_params"),
+        pytest.lazy_fixture("objax_resnet50_params"),
+        pytest.lazy_fixture("haiku_resnet50_params"),
+    ],
+)
+@pytest.mark.usefixtures("safetensors_file", "fs")
+def test_serialize_to_file_in_fs(
+    params: ParamsDictLike, safetensors_file: Path, fs: AbstractFileSystem
+) -> None:
+    safetensors_file = serialize(params=params, filename=safetensors_file, fs=fs)
+    assert isinstance(safetensors_file, Path)
+    assert safetensors_file.exists()
+    assert safetensors_file.as_posix() in fs.ls(safetensors_file.parent.as_posix())

--- a/tests/test_core_save.py
+++ b/tests/test_core_save.py
@@ -9,7 +9,7 @@ from safejax.utils import ParamsDictLike
 @pytest.mark.parametrize(
     "params",
     [
-        pytest.lazy_fixture("single_layer_params"),
+        pytest.lazy_fixture("flax_single_layer_params"),
         pytest.lazy_fixture("flax_resnet50_params"),
         pytest.lazy_fixture("objax_resnet50_params"),
         pytest.lazy_fixture("haiku_resnet50_params"),
@@ -24,7 +24,7 @@ def test_serialize(params: ParamsDictLike) -> None:
 @pytest.mark.parametrize(
     "params",
     [
-        pytest.lazy_fixture("single_layer_params"),
+        pytest.lazy_fixture("flax_single_layer_params"),
         pytest.lazy_fixture("flax_resnet50_params"),
         pytest.lazy_fixture("objax_resnet50_params"),
         pytest.lazy_fixture("haiku_resnet50_params"),

--- a/tests/test_flax.py
+++ b/tests/test_flax.py
@@ -19,7 +19,7 @@ from safejax.utils import flatten_dict
 @pytest.mark.parametrize(
     "params",
     [
-        pytest.lazy_fixture("single_layer_params"),
+        pytest.lazy_fixture("flax_single_layer_params"),
         pytest.lazy_fixture("flax_resnet50_params"),
     ],
 )
@@ -35,7 +35,7 @@ def test_partial_deserialize(params: FlaxParams) -> None:
 @pytest.mark.parametrize(
     "params",
     [
-        pytest.lazy_fixture("single_layer_params"),
+        pytest.lazy_fixture("flax_single_layer_params"),
         pytest.lazy_fixture("flax_resnet50_params"),
     ],
 )
@@ -54,7 +54,7 @@ def test_partial_deserialize_from_file(
 @pytest.mark.parametrize(
     "params",
     [
-        pytest.lazy_fixture("single_layer_params"),
+        pytest.lazy_fixture("flax_single_layer_params"),
         pytest.lazy_fixture("flax_resnet50_params"),
     ],
 )
@@ -96,7 +96,7 @@ def test_safejax_and_msgpack(
 @pytest.mark.parametrize(
     "params",
     [
-        pytest.lazy_fixture("single_layer_params"),
+        pytest.lazy_fixture("flax_single_layer_params"),
         pytest.lazy_fixture("flax_resnet50_params"),
     ],
 )
@@ -136,8 +136,8 @@ def test_safejax_and_msgpack_bytes(params: FlaxParams) -> None:
 @pytest.mark.parametrize(
     "params",
     [
-        pytest.lazy_fixture("single_layer_params"),
-        # pytest.lazy_fixture("flax_resnet50_params"),
+        pytest.lazy_fixture("flax_single_layer_params"),
+        pytest.lazy_fixture("flax_resnet50_params"),
     ],
 )
 def test_safejax_and_state_dict(params: FlaxParams) -> None:


### PR DESCRIPTION
## ✨ Features

- Add `fs` param in both `safejax.core.serialize` and `safejax.core.deserialize`
    - Now `safetensors` files can be uploaded to any fs defined with `fsspec`
    - `safetensors` files can also be loaded from any fs
    - When downloading, it also prepares the model params, not just the file download

## 🔗 Linked Issue/s

#19 

## 🧪 Tests

- [X] Did you implement unit tests if you need to?

If the above checkbox is checked, could you describe how you unit-tested it?

Still using local filesystem, as still considering whether to run the unit tests in a Docker Container that mocks the cloud storage provider e.g. `azurite` or `moto` or just create another process to deploy those servers locally e.g. something similar to what `s3fs` does.

 But there seems to be an issue with that, as mocking does not work with the `mock_s3` decorator, nor with the `mock_s3` context manager, which would be ideal. Instead, the only thing that seems to work with `s3fs` is deploying `moto` locally, and providing that URL to the `s3fs` instance. In any other case, it fails, even though for other libraries such as `boto3` or `botocore` it works fine...