### PR TITLE
✨ Add `metadata` in `safejax.serialize`

### DIFF
--- a/src/safejax/core/load.py
+++ b/src/safejax/core/load.py
@@ -18,7 +18,7 @@ def deserialize(
     freeze_dict: bool = False,
     requires_unflattening: bool = True,
     to_var_collection: bool = False,
-) -> Union[ParamsDictLike, Tuple[Dict[str, str], ParamsDictLike]]:
+) -> Union[ParamsDictLike, Tuple[ParamsDictLike, Dict[str, str]]]:
     """
     Deserialize JAX, Flax, Haiku, or Objax model params from either a `bytes` object or a file path,
     stored using `safetensors.flax.save_file` or directly saved using `safejax.save.serialize` with
@@ -43,7 +43,9 @@ def deserialize(
             Whether to convert the output `Dict` to a `VarCollection` or not. Defaults to `False`.
 
     Returns:
-        A `Dict[str, jnp.DeviceArray]`, `FrozenDict`, or `VarCollection` containing the model params.
+        A `Dict[str, jnp.DeviceArray]`, `FrozenDict`, or `VarCollection` containing the model params,
+        or in case `path_or_buf` is a filename and `metadata` is not empty, a tuple containing the
+        model params and the metadata (in that order).
     """
     metadata = {}
     if isinstance(path_or_buf, bytes):
@@ -89,5 +91,5 @@ def deserialize(
     if freeze_dict:
         return freeze(decoded_params)
     if metadata and len(metadata) > 0:
-        return metadata, decoded_params
+        return decoded_params, metadata
     return decoded_params

--- a/src/safejax/core/load.py
+++ b/src/safejax/core/load.py
@@ -1,11 +1,12 @@
 import warnings
 from pathlib import Path
-from typing import Union
+from typing import Dict, Tuple, Union
 
 from flax.core.frozen_dict import freeze
 from fsspec import AbstractFileSystem
 from objax.variable import VarCollection
-from safetensors.flax import load, load_file
+from safetensors import safe_open
+from safetensors.flax import load
 
 from safejax.typing import ParamsDictLike, PathLike
 from safejax.utils import cast_objax_variables, unflatten_dict
@@ -17,7 +18,7 @@ def deserialize(
     freeze_dict: bool = False,
     requires_unflattening: bool = True,
     to_var_collection: bool = False,
-) -> ParamsDictLike:
+) -> Union[ParamsDictLike, Tuple[Dict[str, str], ParamsDictLike]]:
     """
     Deserialize JAX, Flax, Haiku, or Objax model params from either a `bytes` object or a file path,
     stored using `safetensors.flax.save_file` or directly saved using `safejax.save.serialize` with
@@ -44,6 +45,7 @@ def deserialize(
     Returns:
         A `Dict[str, jnp.DeviceArray]`, `FrozenDict`, or `VarCollection` containing the model params.
     """
+    metadata = {}
     if isinstance(path_or_buf, bytes):
         decoded_params = load(data=path_or_buf)
     elif isinstance(path_or_buf, (str, Path)):
@@ -66,7 +68,11 @@ def deserialize(
                 raise ValueError(
                     f"`path_or_buf` must be a valid file path, not {path_or_buf}."
                 )
-            decoded_params = load_file(filename=filename.as_posix())
+            decoded_params = {}
+            with safe_open(filename.as_posix(), framework="jax") as f:
+                metadata = f.metadata()
+                for k in f.keys():
+                    decoded_params[k] = f.get_tensor(k)
     else:
         raise ValueError(
             "`path_or_buf` must be a `bytes` object or a file path (`str` or"
@@ -82,4 +88,6 @@ def deserialize(
         decoded_params = unflatten_dict(params=decoded_params)
     if freeze_dict:
         return freeze(decoded_params)
+    if metadata and len(metadata) > 0:
+        return metadata, decoded_params
     return decoded_params

--- a/src/safejax/core/save.py
+++ b/src/safejax/core/save.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import warnings
 from pathlib import Path
 from typing import Dict, Union
 
@@ -33,16 +34,25 @@ def serialize(
     """
     params = flatten_dict(params=params)
 
-    if metadata and any(
-        not isinstance(key, str) or not isinstance(value, str)
-        for key, value in metadata.items()
-    ):
-        raise ValueError(
-            "If `metadata` is provided (not `None`), it must be a `Dict[str, str]`"
-            " object. From the `safetensors` documentation: 'Optional text only"
-            " metadata you might want to save in your header. For instance it can be"
-            " useful to specify more about the underlying tensors. This is purely"
-            " informative and does not affect tensor loading.'"
+    if metadata:
+        if any(
+            not isinstance(key, str) or not isinstance(value, str)
+            for key, value in metadata.items()
+        ):
+            raise ValueError(
+                "If `metadata` is provided (not `None`), it must be a `Dict[str, str]`"
+                " object. From the `safetensors` documentation: 'Optional text only"
+                " metadata you might want to save in your header. For instance it can"
+                " be useful to specify more about the underlying tensors. This is"
+                " purely informative and does not affect tensor loading.'"
+            )
+        warnings.warn(
+            "`metadata` param can be provided, but will be ignored when loading the"
+            " params back. The only way to load the metadata as well as the model"
+            " params is to use `safetensors.safe_open`, and access the metadata with"
+            " `.metadata()`, otherwise, it will be ignored when calling"
+            " `safetensors.load` or `safetensors.load_file`. More information at"
+            " https://github.com/huggingface/safetensors/issues/147."
         )
     if filename:
         if not isinstance(filename, (str, Path)):

--- a/src/safejax/core/save.py
+++ b/src/safejax/core/save.py
@@ -50,14 +50,15 @@ def serialize(
                 " be useful to specify more about the underlying tensors. This is"
                 " purely informative and does not affect tensor loading.'"
             )
-        warnings.warn(
-            "`metadata` param can be provided, but will be ignored when loading the"
-            " params back. The only way to load the metadata as well as the model"
-            " params is to use `safetensors.safe_open`, and access the metadata with"
-            " `.metadata()`, otherwise, it will be ignored when calling"
-            " `safetensors.load` or `safetensors.load_file`. More information at"
-            " https://github.com/huggingface/safetensors/issues/147."
-        )
+        if not filename:
+            warnings.warn(
+                "`metadata` param will be ignored when trying to `deserialize` from"
+                " bytes, if you want to save the `metadata` to be loaded later, you can"
+                " set the `filename` param to dump the `metadata` along with the model"
+                " params in a file, either to be loaded back using `deserialize` from"
+                " `path_or_buf` or using `safetensors.safe_open`. More information at"
+                " https://github.com/huggingface/safetensors/issues/147."
+            )
     if filename:
         if not isinstance(filename, (str, Path)):
             raise ValueError(

--- a/src/safejax/typing.py
+++ b/src/safejax/typing.py
@@ -1,12 +1,14 @@
 from pathlib import Path
 from typing import Dict, Union
 
+import numpy as np
 from flax.core.frozen_dict import FrozenDict
 from jax import numpy as jnp
 from objax.variable import BaseVar, StateVar, VarCollection
 
 PathLike = Union[str, Path]
 
+NumpyArrayDict = Dict[str, np.ndarray]
 JaxDeviceArrayDict = Dict[str, jnp.DeviceArray]
 HaikuParams = Dict[str, JaxDeviceArrayDict]
 ObjaxDict = Dict[str, Union[BaseVar, StateVar]]

--- a/src/safejax/utils.py
+++ b/src/safejax/utils.py
@@ -6,7 +6,7 @@ from flax.core.frozen_dict import FrozenDict
 from jax import numpy as jnp
 from objax.variable import BaseState, BaseVar, RandomState, StateVar, TrainRef, TrainVar
 
-from safejax.typing import JaxDeviceArrayDict, ObjaxDict, ParamsDictLike
+from safejax.typing import JaxDeviceArrayDict, NumpyArrayDict, ObjaxDict, ParamsDictLike
 
 OBJAX_VARIABLES = {
     "BaseVar": BaseVar,
@@ -23,7 +23,7 @@ def flatten_dict(
     params: ParamsDictLike,
     key_prefix: Union[str, None] = None,
     include_objax_variables: bool = False,
-) -> Union[Dict[str, np.ndarray], Dict[str, jnp.DeviceArray]]:
+) -> Union[NumpyArrayDict, JaxDeviceArrayDict]:
     """
     Flatten a `Dict`, `FrozenDict`, or `VarCollection`, for more detailed information on
     the supported input types check `safejax.typing.ParamsDictLike`.
@@ -66,10 +66,7 @@ def flatten_dict(
     return flattened_params
 
 
-# Note that this function has a less restrictive type hint than the `flatten_dict` function.
-# This is because the `unflatten_dict` function is generic, and it can be used to unflatten
-# any `Dict` where the keys are expanded using the `.` character as a separator.
-def unflatten_dict(params: Dict[str, Any]) -> Dict[str, Any]:
+def unflatten_dict(params: Union[NumpyArrayDict, JaxDeviceArrayDict]) -> Dict[str, Any]:
     """
     Unflatten a `Dict` where the keys should be expanded using the `.` character
     as a separator.
@@ -120,7 +117,7 @@ def unflatten_dict(params: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def cast_objax_variables(
-    params: Dict[str, jnp.DeviceArray]
+    params: JaxDeviceArrayDict,
 ) -> Union[JaxDeviceArrayDict, ObjaxDict]:
     """
     Cast the `jnp.DeviceArray` to their corresponding `objax.variable` types.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Dict
 
 import fsspec
 import haiku as hk
@@ -84,6 +85,13 @@ def objax_resnet50() -> objax.nn.Sequential:
 @pytest.fixture
 def objax_resnet50_params(objax_resnet50: objax.nn.Sequential) -> VarCollection:
     return objax_resnet50.vars()
+
+
+@pytest.fixture
+def metadata() -> Dict[str, str]:
+    return {
+        "test": "test",
+    }
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_core_load.py
+++ b/tests/test_core_load.py
@@ -99,6 +99,27 @@ def test_deserialize_from_file(
     assert_over_trees(params=params, decoded_params=decoded_params)
 
 
+@pytest.mark.usefixtures("flax_resnet50_params", "safetensors_file", "metadata")
+def test_deserialize_from_file_with_metadata(
+    flax_resnet50_params: ParamsDictLike,
+    safetensors_file: Path,
+    metadata: Dict[str, str],
+) -> None:
+    safetensors_file = serialize(
+        params=flax_resnet50_params, filename=safetensors_file, metadata=metadata
+    )
+    decoded_params, metadata = deserialize(path_or_buf=safetensors_file)
+    assert isinstance(decoded_params, dict)
+    assert len(decoded_params) > 0
+    assert id(decoded_params) != id(flax_resnet50_params)
+    assert decoded_params.keys() == flax_resnet50_params.keys()
+    assert metadata is not None
+    assert isinstance(metadata, dict)
+    assert len(metadata) > 0
+
+    assert_over_trees(params=flax_resnet50_params, decoded_params=decoded_params)
+
+
 @pytest.mark.parametrize(
     "params, serialize_kwargs, deserialize_kwargs, expected_output_type",
     [

--- a/tests/test_core_save.py
+++ b/tests/test_core_save.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Dict
 
 import pytest
 from fsspec.spec import AbstractFileSystem
@@ -20,6 +21,25 @@ def test_serialize(params: ParamsDictLike) -> None:
     encoded_params = serialize(params=params)
     assert isinstance(encoded_params, bytes)
     assert len(encoded_params) > 0
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.lazy_fixture("flax_single_layer_params"),
+        pytest.lazy_fixture("flax_resnet50_params"),
+        pytest.lazy_fixture("objax_resnet50_params"),
+        pytest.lazy_fixture("haiku_resnet50_params"),
+    ],
+)
+@pytest.mark.usefixtures("metadata")
+def test_serialize_with_metadata(
+    params: ParamsDictLike, metadata: Dict[str, str]
+) -> None:
+    encoded_params = serialize(params=params, metadata=metadata)
+    assert isinstance(encoded_params, bytes)
+    assert len(encoded_params) > 0
+    assert encoded_params.__contains__(b"metadata")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## ✨ Features

- Add `metadata` param in `safejax.serialize`
- `deserialize` returns `metadata` if available

## 🧪 Tests

- [x] Did you implement unit tests if required?

If the above checkbox is checked, describe how you unit-tested it.

Add unit tests when calling `serialize` with `filename`, and make sure it's loaded back on `deserialize`. 