### PR TITLE
🧪 Add assertions over `pytrees` with `chex`

### DIFF
--- a/tests/test_core_load.py
+++ b/tests/test_core_load.py
@@ -10,6 +10,8 @@ from safejax.core.load import deserialize
 from safejax.core.save import serialize
 from safejax.typing import ParamsDictLike
 
+from .utils import assert_over_trees
+
 
 @pytest.mark.parametrize(
     "params, deserialize_kwargs, expected_output_type",
@@ -45,6 +47,8 @@ def test_deserialize(
     assert id(decoded_params) != id(params)
     assert decoded_params.keys() == params.keys()
 
+    assert_over_trees(params=params, decoded_params=decoded_params)
+
 
 @pytest.mark.parametrize(
     "params, deserialize_kwargs, expected_output_type",
@@ -70,7 +74,7 @@ def test_deserialize(
 )
 @pytest.mark.usefixtures("safetensors_file")
 def test_deserialize_from_file(
-    params: FrozenDict,
+    params: ParamsDictLike,
     deserialize_kwargs: Dict[str, Any],
     expected_output_type: Union[dict, FrozenDict, VarCollection],
     safetensors_file: Path,
@@ -81,6 +85,8 @@ def test_deserialize_from_file(
     assert len(decoded_params) > 0
     assert id(decoded_params) != id(params)
     assert decoded_params.keys() == params.keys()
+
+    assert_over_trees(params=params, decoded_params=decoded_params)
 
 
 @pytest.mark.parametrize(
@@ -107,7 +113,7 @@ def test_deserialize_from_file(
 )
 @pytest.mark.usefixtures("safetensors_file", "fs")
 def test_deserialize_from_file_in_fs(
-    params: FrozenDict,
+    params: ParamsDictLike,
     deserialize_kwargs: Dict[str, Any],
     expected_output_type: Union[dict, FrozenDict, VarCollection],
     safetensors_file: Path,
@@ -121,3 +127,5 @@ def test_deserialize_from_file_in_fs(
     assert len(decoded_params) > 0
     assert id(decoded_params) != id(params)
     assert decoded_params.keys() == params.keys()
+
+    assert_over_trees(params=params, decoded_params=decoded_params)

--- a/tests/test_haiku.py
+++ b/tests/test_haiku.py
@@ -5,6 +5,8 @@ import pytest
 from safejax.haiku import deserialize, serialize
 from safejax.typing import HaikuParams
 
+from .utils import assert_over_trees
+
 
 @pytest.mark.parametrize(
     "params",
@@ -22,6 +24,8 @@ def test_serialize_and_deserialize(params: HaikuParams) -> None:
     assert len(decoded_params) > 0
     assert id(decoded_params) != id(params)
     assert decoded_params.keys() == params.keys()
+
+    assert_over_trees(params=params, decoded_params=decoded_params)
 
 
 @pytest.mark.parametrize(
@@ -43,3 +47,5 @@ def test_serialize_and_deserialize_from_file(
     assert len(decoded_params) > 0
     assert id(decoded_params) != id(params)
     assert decoded_params.keys() == params.keys()
+
+    assert_over_trees(params=params, decoded_params=decoded_params)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,44 @@
+import warnings
+
+import chex
+import jax
+from flax.core.frozen_dict import FrozenDict, unfreeze
+from objax.variable import VarCollection
+
+from safejax.typing import ParamsDictLike
+
+
+def assert_over_trees(params: ParamsDictLike, decoded_params: ParamsDictLike) -> None:
+    """Assertions using `chex` to compare two trees of parameters.
+
+    Note:
+        This function does not support `objax.variable.VarCollection` objects yet,
+        so the assertions are just done over `jax`, `flax`, and `haiku` params.
+
+    Args:
+        params: a `ParamsDictLike` object with the original parameters.
+        decoded_params: a `ParamsDictLike` object with the decoded parameters using `safejax`.
+
+    Raises:
+        AssertionError: if the two trees are not equal on dtype, shape, structure, and values.
+    """
+    if isinstance(params, VarCollection) or isinstance(decoded_params, VarCollection):
+        warnings.warn(
+            "This function does not support `objax.variable.VarCollection` objects yet."
+        )
+    else:
+        params = unfreeze(params) if isinstance(params, FrozenDict) else params
+        decoded_params = (
+            unfreeze(decoded_params)
+            if isinstance(decoded_params, FrozenDict)
+            else decoded_params
+        )
+        params_tree = jax.tree_util.tree_map(lambda x: x, params)
+        decoded_params_tree = jax.tree_util.tree_map(lambda x: x, decoded_params)
+
+        chex.assert_trees_all_close(
+            params_tree, decoded_params_tree
+        )  # static and jittable static
+        chex.assert_trees_all_equal_dtypes(params_tree, decoded_params_tree)
+        chex.assert_trees_all_equal_shapes(params_tree, decoded_params_tree)
+        chex.assert_trees_all_equal_structs(params_tree, decoded_params_tree)


### PR DESCRIPTION
## ✨ Features

- Add `tests/utils.py` and `tests/__init__.py` to import it as `import .utils`
- Implement `assert_over_trees` function in `tests/utils.py`
- Add `chex` assertions to `jax`, `flax`, and `haiku` params

## 🔗 Linked Issue/s

#24 

## 📌 Notes

* `jaxtyping` is another potential library to assert over trees
* `objax.variable.VarCollection` is not yet supported as still needs more refinement

## 🧪 Tests

- [X] Did you implement unit tests if required?

If the above checkbox is checked, describe how you unit-tested it.

Add assertions over trees with `chex` from @deepmind to make sure that the original params dict matches the one serialized and deserialized using `safejax` with `safetensors` as the tensor storage format.